### PR TITLE
documentation patch, add () when instantiation multi_index

### DIFF
--- a/doc/tutorial/key_extraction.html
+++ b/doc/tutorial/key_extraction.html
@@ -409,7 +409,7 @@ key are accomplished by passing tuples with the values searched:
 </p>
 
 <blockquote><pre>
-<span class=identifier>phonebook</span> <span class=identifier>pb</span><span class=special>;</span>
+<span class=identifier>phonebook</span> <span class=identifier>pb()</span><span class=special>;</span>
 <span class=special>...</span>
 <span class=comment>// search for Dorothea White's number</span>
 <span class=identifier>phonebook</span><span class=special>::</span><span class=identifier>iterator</span> <span class=identifier>it</span><span class=special>=</span><span class=identifier>pb</span><span class=special>.</span><span class=identifier>find</span><span class=special>(</span><span class=identifier>boost</span><span class=special>::</span><span class=identifier>make_tuple</span><span class=special>(</span><span class=string>&quot;White&quot;</span><span class=special>,</span><span class=string>&quot;Dorothea&quot;</span><span class=special>));</span>


### PR DESCRIPTION
Here is an abridged error message that i get if i don't have () in my code.

error: no matching function for call to 'boost::multi_index::multi_index_container
[...]
note: boost::multi_index::multi_index_container<Value, IndexSpecifierList, Allocator>::multi_index_container(const boost::multi_index::multi_index_container<Value, IndexSpecifierList, Allocator>&)
[...]
note:   candidate expects 1 argument, 0 provided
