### PR TITLE
Fix cast to prevent -Wconversion warning in g++.

### DIFF
--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -1271,7 +1271,7 @@ private:
 
   void calculate_max_load()
   {
-    float fml=static_cast<float>(mlf*bucket_count());
+    float fml=mlf*static_cast<float>(bucket_count());
     max_load=(std::numeric_limits<size_type>::max)();
     if(max_load>fml)max_load=static_cast<size_type>(fml);
   }


### PR DESCRIPTION
This change fixes a -Wconversion warning in g++ version 4.9.2 on mac yosemite.  For example, in multi_index/example, I run

*g++ -Wconversion -I../../.. -o hashed hashed.cpp*

and get the warning.  With the change, I do not get the warning.  I'm guessing that the compiler is being picky since bucket_count() is unsigned.  mlf is a float, so I think this still has the intended effect.