### PR TITLE
Use correct value_type from super class.

### DIFF
--- a/include/boost/multi_index/detail/ord_index_impl.hpp
+++ b/include/boost/multi_index/detail/ord_index_impl.hpp
@@ -1403,7 +1403,7 @@ public:
   }
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
-  ordered_index& operator=(std::initializer_list<value_type> list)
+  ordered_index& operator=(std::initializer_list<typename super::value_type> list)
   {
     this->final()=list;
     return *this;


### PR DESCRIPTION
error: use of undeclared identifier 'value_type'

Happens in c++11 mode only.