### PR TITLE
Another c++11 issue with value_type

### DIFF
--- a/include/boost/multi_index/detail/index_base.hpp
+++ b/include/boost/multi_index/detail/index_base.hpp
@@ -83,10 +83,8 @@ protected:
     final_allocator_type>                     index_loader_type;
 #endif
 
-private:
   typedef Value                               value_type;
 
-protected:
   explicit index_base(const ctor_args_list&,const Allocator&){}
 
   index_base(

--- a/include/boost/multi_index/detail/ord_index_impl.hpp
+++ b/include/boost/multi_index/detail/ord_index_impl.hpp
@@ -1404,7 +1404,8 @@ public:
   }
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
-  ordered_index& operator=(std::initializer_list<value_type> list)
+  ordered_index& operator=(
+    std::initializer_list<BOOST_DEDUCED_TYPENAME super::value_type> list)
   {
     this->final()=list;
     return *this;


### PR DESCRIPTION
See #6 and 3f8d49acea7857383dbae904048d75f4c2099b51 for the first patch.
Now operator= needs to use the typedef from the super class which in turn can not be private anymore