### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/multi_index/detail/auto_space.hpp
+++ b/include/boost/multi_index/detail/auto_space.hpp
@@ -47,15 +47,31 @@ struct auto_space:private noncopyable
 {
   typedef typename boost::detail::allocator::rebind_to<
     Allocator,T
-  >::type::pointer pointer;
+  >::type allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename allocator::pointer pointer;
+#else
+  typedef std::allocator_traits<allocator> traits;
+  typedef typename traits::pointer pointer;
+#endif
 
   explicit auto_space(const Allocator& al=Allocator(),std::size_t n=1):
-  al_(al),n_(n),data_(n_?al_.allocate(n_):pointer(0))
+  al_(al),n_(n),
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  data_(n_?al_.allocate(n_):pointer(0))
+#else
+  data_(n_?traits::allocate(al_,n_):pointer(0))
+#endif
   {}
 
   ~auto_space()
   {
-    if(n_)al_.deallocate(data_,n_);
+    if(n_)
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+      al_.deallocate(data_,n_);
+#else
+      traits::deallocate(al_,data_,n_);
+#endif
   }
 
   Allocator get_allocator()const{return al_;}
@@ -70,10 +86,9 @@ struct auto_space:private noncopyable
   }
     
 private:
-  typename boost::detail::allocator::rebind_to<
-    Allocator,T>::type                          al_;
-  std::size_t                                   n_;
-  pointer                                       data_;
+  allocator   al_;
+  std::size_t n_;
+  pointer     data_;
 };
 
 template<typename T,typename Allocator>

--- a/include/boost/multi_index/detail/copy_map.hpp
+++ b/include/boost/multi_index/detail/copy_map.hpp
@@ -22,6 +22,7 @@
 #include <boost/noncopyable.hpp>
 #include <cstddef>
 #include <functional>
+#include <memory>
 
 namespace boost{
 
@@ -84,7 +85,7 @@ public:
   void clone(Node* node)
   {
     (spc.data()+n)->first=node;
-    (spc.data()+n)->second=raw_ptr<Node*>(al_.allocate(1));
+    (spc.data()+n)->second=raw_ptr<Node*>(allocate());
     BOOST_TRY{
       boost::detail::allocator::construct(
         boost::addressof((spc.data()+n)->second->value()),node->value());
@@ -119,7 +120,12 @@ private:
   typedef typename boost::detail::allocator::rebind_to<
     Allocator,Node
   >::type                                               allocator_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer              allocator_pointer;
+#else
+  typedef std::allocator_traits<allocator_type>         allocator_traits;
+  typedef typename allocator_traits::pointer            allocator_pointer;
+#endif
 
   allocator_type                                        al_;
   std::size_t                                           size_;
@@ -129,9 +135,22 @@ private:
   Node*                                                 header_cpy_;
   bool                                                  released;
 
+  allocator_pointer allocate()
+  {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+    return al_.allocate(1);
+#else
+    return allocator_traits::allocate(al_,1);
+#endif
+  }
+
   void deallocate(Node* node)
   {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     al_.deallocate(static_cast<allocator_pointer>(node),1);
+#else
+    allocator_traits::deallocate(al_,static_cast<allocator_pointer>(node),1);
+#endif
   }
 };
 

--- a/include/boost/multi_index/detail/hash_index_node.hpp
+++ b/include/boost/multi_index/detail/hash_index_node.hpp
@@ -17,6 +17,7 @@
 #include <boost/detail/allocator_utilities.hpp>
 #include <boost/multi_index/detail/raw_ptr.hpp>
 #include <utility>
+#include <memory>
 
 namespace boost{
 
@@ -101,22 +102,32 @@ struct hashed_index_base_node_impl
 {
   typedef typename
   boost::detail::allocator::rebind_to<
-      Allocator,hashed_index_base_node_impl
-  >::type::pointer                          base_pointer;
-  typedef typename
-  boost::detail::allocator::rebind_to<
     Allocator,hashed_index_base_node_impl
-  >::type::const_pointer                    const_base_pointer;
+  >::type                                        base_allocator;
   typedef typename
   boost::detail::allocator::rebind_to<
     Allocator,
     hashed_index_node_impl<Allocator>
-  >::type::pointer                          pointer;
-  typedef typename
-  boost::detail::allocator::rebind_to<
-    Allocator,
-    hashed_index_node_impl<Allocator>
-  >::type::const_pointer                    const_pointer;
+  >::type                                        node_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename base_allocator::pointer       base_pointer;
+  typedef typename base_allocator::const_pointer const_base_pointer;
+  typedef typename node_allocator::pointer       pointer;
+  typedef typename node_allocator::const_pointer const_pointer;
+#else
+  typedef typename std::allocator_traits<
+    base_allocator
+  >::pointer                                     base_pointer;
+  typedef typename std::allocator_traits<
+    base_allocator
+  >::const_pointer                               const_base_pointer;
+  typedef typename std::allocator_traits<
+    node_allocator
+  >::pointer                                     pointer;
+  typedef typename std::allocator_traits<
+    node_allocator
+  >::const_pointer                               const_pointer;
+#endif
 
   pointer& prior(){return prior_;}
   pointer  prior()const{return prior_;}

--- a/include/boost/multi_index/detail/ord_index_impl.hpp
+++ b/include/boost/multi_index/detail/ord_index_impl.hpp
@@ -69,6 +69,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <utility>
+#include <memory>
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
 #include <initializer_list>
@@ -162,8 +163,13 @@ public:
     value_type,KeyFromValue,Compare>                 value_compare;
   typedef tuple<key_from_value,key_compare>          ctor_args;
   typedef typename super::final_allocator_type       allocator_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::reference         reference;
   typedef typename allocator_type::const_reference   const_reference;
+#else
+  typedef value_type&                                reference;
+  typedef const value_type&                          const_reference;
+#endif
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
   typedef safe_mode::safe_iterator<
@@ -177,8 +183,14 @@ public:
 
   typedef std::size_t                                size_type;      
   typedef std::ptrdiff_t                             difference_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer           pointer;
   typedef typename allocator_type::const_pointer     const_pointer;
+#else
+  typedef std::allocator_traits<allocator_type>      allocator_traits;
+  typedef typename allocator_traits::pointer         pointer;
+  typedef typename allocator_traits::const_pointer   const_pointer;
+#endif
   typedef typename
     boost::reverse_iterator<iterator>                reverse_iterator;
   typedef typename

--- a/include/boost/multi_index/detail/ord_index_node.hpp
+++ b/include/boost/multi_index/detail/ord_index_node.hpp
@@ -42,6 +42,7 @@
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <cstddef>
+#include <memory>
 #include <boost/detail/allocator_utilities.hpp>
 #include <boost/multi_index/detail/raw_ptr.hpp>
 
@@ -68,20 +69,33 @@ template<typename AugmentPolicy,typename Allocator>
 struct ordered_index_node_impl; /* fwd decl. */
 
 template<typename AugmentPolicy,typename Allocator>
-struct ordered_index_node_std_base
+struct ordered_index_node_traits
 {
   typedef typename
   boost::detail::allocator::rebind_to<
     Allocator,
     ordered_index_node_impl<AugmentPolicy,Allocator>
-  >::type::pointer                                   pointer;
-  typedef typename
-  boost::detail::allocator::rebind_to<
-    Allocator,
-    ordered_index_node_impl<AugmentPolicy,Allocator>
-  >::type::const_pointer                             const_pointer;
-  typedef ordered_index_color&                       color_ref;
-  typedef pointer&                                   parent_ref;
+  >::type                                            allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename allocator::pointer                pointer;
+  typedef typename allocator::const_pointer          const_pointer;
+#else
+  typedef std::allocator_traits<allocator>           allocator_traits;
+  typedef typename allocator_traits::pointer         pointer;
+  typedef typename allocator_traits::const_pointer   const_pointer;
+#endif
+};
+
+template<typename AugmentPolicy,typename Allocator>
+struct ordered_index_node_std_base
+{
+  typedef ordered_index_node_traits<
+    AugmentPolicy,Allocator>                  node_traits;
+  typedef typename node_traits::allocator     node_allocator;
+  typedef typename node_traits::pointer       pointer;
+  typedef typename node_traits::const_pointer const_pointer;
+  typedef ordered_index_color&                color_ref;
+  typedef pointer&                            parent_ref;
 
   ordered_index_color& color(){return color_;}
   ordered_index_color  color()const{return color_;}
@@ -217,10 +231,7 @@ struct ordered_index_node_impl_base:
         ordered_index_node_compressed_base<AugmentPolicy,Allocator>
        >::value%2)||
       !(is_same<
-        typename boost::detail::allocator::rebind_to<
-          Allocator,
-          ordered_index_node_impl<AugmentPolicy,Allocator>
-        >::type::pointer,
+        typename ordered_index_node_traits<AugmentPolicy,Allocator>::pointer,
         ordered_index_node_impl<AugmentPolicy,Allocator>*>::value),
       ordered_index_node_std_base<AugmentPolicy,Allocator>,
       ordered_index_node_compressed_base<AugmentPolicy,Allocator>

--- a/include/boost/multi_index/detail/rnd_index_node.hpp
+++ b/include/boost/multi_index/detail/rnd_index_node.hpp
@@ -20,6 +20,7 @@
 #include <boost/multi_index/detail/raw_ptr.hpp>
 #include <cstddef>
 #include <functional>
+#include <memory>
 
 namespace boost{
 
@@ -33,16 +34,25 @@ struct random_access_index_node_impl
   typedef typename
   boost::detail::allocator::rebind_to<
     Allocator,random_access_index_node_impl
-  >::type::pointer                          pointer;
-  typedef typename
-  boost::detail::allocator::rebind_to<
-    Allocator,random_access_index_node_impl
-  >::type::const_pointer                    const_pointer;
+  >::type                                        node_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename node_allocator::pointer       pointer;
+  typedef typename node_allocator::const_pointer const_pointer;
+#else
+  typedef std::allocator_traits<node_allocator>  node_traits;
+  typedef typename node_traits::pointer          pointer;
+  typedef typename node_traits::const_pointer    const_pointer;
+#endif
   typedef typename
   boost::detail::allocator::rebind_to<
     Allocator,pointer
-  >::type::pointer                          ptr_pointer;
-
+  >::type                                        ptr_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename ptr_allocator::pointer        ptr_pointer;
+#else
+  typedef std::allocator_traits<ptr_allocator>   ptr_traits;
+  typedef typename ptr_traits::pointer           ptr_pointer;
+#endif
   ptr_pointer& up(){return up_;}
   ptr_pointer  up()const{return up_;}
 

--- a/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
+++ b/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
@@ -20,6 +20,7 @@
 #include <boost/multi_index/detail/rnd_index_node.hpp>
 #include <boost/noncopyable.hpp>
 #include <cstddef>
+#include <memory>
 
 namespace boost{
 
@@ -43,7 +44,14 @@ public:
   typedef typename node_impl_type::pointer              value_type;
   typedef typename boost::detail::allocator::rebind_to<
     Allocator,value_type
-  >::type::pointer                                      pointer;
+  >::type                                               value_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename value_allocator::pointer             pointer;
+#else
+  typedef typename std::allocator_traits<
+    value_allocator
+  >::pointer                                            pointer;
+#endif
 
   random_access_index_ptr_array(
     const Allocator& al,value_type end_,std::size_t sz):

--- a/include/boost/multi_index/detail/seq_index_node.hpp
+++ b/include/boost/multi_index/detail/seq_index_node.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <algorithm>
+#include <memory>
 #include <boost/detail/allocator_utilities.hpp>
 #include <boost/multi_index/detail/raw_ptr.hpp>
 
@@ -32,12 +33,15 @@ struct sequenced_index_node_impl
   typedef typename
   boost::detail::allocator::rebind_to<
     Allocator,sequenced_index_node_impl
-  >::type::pointer                      pointer;
-  typedef typename
-  boost::detail::allocator::rebind_to<
-    Allocator,sequenced_index_node_impl
-  >::type::const_pointer                const_pointer;
-
+  >::type                                          node_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename node_allocator::pointer         pointer;
+  typedef typename node_allocator::const_pointer   const_pointer;
+#else
+  typedef std::allocator_traits<node_allocator>    allocator_traits;
+  typedef typename allocator_traits::pointer       pointer;
+  typedef typename allocator_traits::const_pointer const_pointer;
+#endif
   pointer& prior(){return prior_;}
   pointer  prior()const{return prior_;}
   pointer& next(){return next_;}

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -45,6 +45,7 @@
 #include <functional>
 #include <iterator>
 #include <utility>
+#include <memory>
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
 #include <initializer_list>
@@ -127,10 +128,18 @@ public:
   typedef tuple<std::size_t,
     key_from_value,hasher,key_equal>                 ctor_args;
   typedef typename super::final_allocator_type       allocator_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer           pointer;
   typedef typename allocator_type::const_pointer     const_pointer;
   typedef typename allocator_type::reference         reference;
   typedef typename allocator_type::const_reference   const_reference;
+#else
+  typedef std::allocator_traits<allocator_type>      allocator_traits;
+  typedef typename allocator_traits::pointer         pointer;
+  typedef typename allocator_traits::const_pointer   const_pointer;
+  typedef value_type&                                reference;
+  typedef const value_type&                          const_reference;
+#endif
   typedef std::size_t                                size_type;      
   typedef std::ptrdiff_t                             difference_type;
 

--- a/include/boost/multi_index/random_access_index.hpp
+++ b/include/boost/multi_index/random_access_index.hpp
@@ -45,6 +45,7 @@
 #include <functional>
 #include <stdexcept> 
 #include <utility>
+#include <memory>
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
 #include<initializer_list>
@@ -114,8 +115,13 @@ public:
   typedef typename node_type::value_type           value_type;
   typedef tuples::null_type                        ctor_args;
   typedef typename super::final_allocator_type     allocator_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::reference       reference;
   typedef typename allocator_type::const_reference const_reference;
+#else
+  typedef value_type&                              reference;
+  typedef const value_type&                        const_reference;
+#endif
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
   typedef safe_mode::safe_iterator<
@@ -129,8 +135,14 @@ public:
 
   typedef std::size_t                              size_type;      
   typedef std::ptrdiff_t                           difference_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer         pointer;
   typedef typename allocator_type::const_pointer   const_pointer;
+#else
+  typedef std::allocator_traits<allocator_type>    allocator_traits;
+  typedef typename allocator_traits::pointer       pointer;
+  typedef typename allocator_traits::const_pointer const_pointer;
+#endif
   typedef typename
     boost::reverse_iterator<iterator>              reverse_iterator;
   typedef typename

--- a/include/boost/multi_index/sequenced_index.hpp
+++ b/include/boost/multi_index/sequenced_index.hpp
@@ -42,6 +42,7 @@
 #include <cstddef>
 #include <functional>
 #include <utility>
+#include <memory>
 
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
 #include<initializer_list>
@@ -106,8 +107,13 @@ public:
   typedef typename node_type::value_type              value_type;
   typedef tuples::null_type                           ctor_args;
   typedef typename super::final_allocator_type        allocator_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::reference          reference;
   typedef typename allocator_type::const_reference    const_reference;
+#else
+  typedef value_type&                                 reference;
+  typedef const value_type&                           const_reference;
+#endif
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
   typedef safe_mode::safe_iterator<
@@ -121,8 +127,14 @@ public:
 
   typedef std::size_t                                 size_type;      
   typedef std::ptrdiff_t                              difference_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer            pointer;
   typedef typename allocator_type::const_pointer      const_pointer;
+#else
+  typedef std::allocator_traits<allocator_type>       allocator_traits;
+  typedef typename allocator_traits::pointer          pointer;
+  typedef typename allocator_traits::const_pointer    const_pointer;
+#endif
   typedef typename
     boost::reverse_iterator<iterator>                 reverse_iterator;
   typedef typename

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -17,6 +17,7 @@
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <algorithm>
+#include <memory>
 #include <boost/core/addressof.hpp>
 #include <boost/detail/allocator_utilities.hpp>
 #include <boost/detail/no_exceptions_support.hpp>
@@ -90,11 +91,19 @@ class multi_index_container:
         Value,IndexSpecifierList,Allocator>::type
     >::type>,
   BOOST_MULTI_INDEX_PRIVATE_IF_MEMBER_TEMPLATE_FRIENDS detail::header_holder<
-    typename boost::detail::allocator::rebind_to<
-      Allocator,
-      typename detail::multi_index_node_type<
-        Value,IndexSpecifierList,Allocator>::type
-    >::type::pointer,
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typename std::allocator_traits<
+#endif
+      typename boost::detail::allocator::rebind_to<
+        Allocator,
+        typename detail::multi_index_node_type<
+          Value,IndexSpecifierList,Allocator>::type
+      >::type
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+    ::pointer,
+#else
+    >::pointer,
+#endif
     multi_index_container<Value,IndexSpecifierList,Allocator> >,
   public detail::multi_index_base_type<
     Value,IndexSpecifierList,Allocator>::type
@@ -125,12 +134,17 @@ private:
     Allocator,
     typename super::node_type
   >::type                                         node_allocator;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+  typedef typename node_allocator::pointer        node_pointer;
+#else
+  typedef std::allocator_traits<node_allocator>   node_allocator_traits;
+  typedef typename node_allocator_traits::pointer node_pointer;
+#endif
   typedef ::boost::base_from_member<
     node_allocator>                               bfm_allocator;
   typedef detail::header_holder<
-    typename node_allocator::pointer,
+    node_pointer,
     multi_index_container>                        bfm_header;
-
 
 public:
   /* All types are inherited from super, a few are explicitly
@@ -528,13 +542,20 @@ BOOST_MULTI_INDEX_PROTECTED_IF_MEMBER_TEMPLATE_FRIENDS:
 
   node_type* allocate_node()
   {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     return &*bfm_allocator::member.allocate(1);
+#else
+    return &*node_allocator_traits::allocate(bfm_allocator::member,1);
+#endif
   }
 
   void deallocate_node(node_type* x)
   {
-    typedef typename node_allocator::pointer node_pointer;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     bfm_allocator::member.deallocate(static_cast<node_pointer>(x),1);
+#else
+    node_allocator_traits::deallocate(bfm_allocator::member,static_cast<node_pointer>(x),1);
+#endif
   }
 
   bool empty_()const


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits.

Signed-off-by: Daniela Engert <dani@ngrt.de>