### PR TITLE
Using allocator's size_type to control sizeof unordered containers so that it is fixed in a 32/64 shd mem context

### DIFF
--- a/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
+++ b/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
@@ -47,10 +47,11 @@ public:
   >::type                                               value_allocator;
 #ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename value_allocator::pointer             pointer;
+  typedef typename value_allocator::size_type           value_allocator_size_type;
 #else
-  typedef typename std::allocator_traits<
-    value_allocator
-  >::pointer                                            pointer;
+  typedef std::allocator_traits<value_allocator>        value_allocator_traits;
+  typedef typename value_allocator_traits::pointer      pointer;
+  typedef typename value_allocator_traits::size_type    value_allocator_size_type;
 #endif
 
   random_access_index_ptr_array(
@@ -117,8 +118,8 @@ public:
   }
 
 private:
-  std::size_t                      size_;
-  std::size_t                      capacity_;
+  value_allocator_size_type        size_;
+  value_allocator_size_type        capacity_;
   auto_space<value_type,Allocator> spc;
 
   pointer ptrs()const

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -131,12 +131,16 @@ public:
 #ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename allocator_type::pointer           pointer;
   typedef typename allocator_type::const_pointer     const_pointer;
+  typedef typename allocator_type::size_type         allocator_size_type;
+  typedef typename allocator_type::difference_type   allocator_diff_type;
   typedef typename allocator_type::reference         reference;
   typedef typename allocator_type::const_reference   const_reference;
 #else
   typedef std::allocator_traits<allocator_type>      allocator_traits;
   typedef typename allocator_traits::pointer         pointer;
   typedef typename allocator_traits::const_pointer   const_pointer;
+  typedef typename allocator_traits::size_type       allocator_size_type;
+  typedef typename allocator_traits::difference_type allocator_diff_type;
   typedef value_type&                                reference;
   typedef const value_type&                          const_reference;
 #endif
@@ -1619,7 +1623,7 @@ private:
   key_equal                    eq_;
   bucket_array_type            buckets;
   float                        mlf;
-  size_type                    max_load;
+  allocator_size_type          max_load;
       
 #if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)&&\
     BOOST_WORKAROUND(__MWERKS__,<=0x3003)

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -136,9 +136,11 @@ private:
   >::type                                         node_allocator;
 #ifdef BOOST_NO_CXX11_ALLOCATOR
   typedef typename node_allocator::pointer        node_pointer;
+  typedef typename node_allocator::size_type      node_allocator_size_type;
 #else
   typedef std::allocator_traits<node_allocator>   node_allocator_traits;
   typedef typename node_allocator_traits::pointer node_pointer;
+  typedef typename node_allocator_traits::size_type node_allocator_size_type;
 #endif
   typedef ::boost::base_from_member<
     node_allocator>                               bfm_allocator;
@@ -575,7 +577,7 @@ BOOST_MULTI_INDEX_PROTECTED_IF_MEMBER_TEMPLATE_FRIENDS:
 
   std::size_t max_size_()const
   {
-    return static_cast<std::size_t >(-1);
+    return static_cast<node_allocator_size_type>(-1);
   }
 
   template<typename Variant>
@@ -995,7 +997,7 @@ BOOST_MULTI_INDEX_PROTECTED_IF_MEMBER_TEMPLATE_FRIENDS:
 #endif
 
 private:
-  std::size_t node_count;
+  node_allocator_size_type node_count;
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)&&\
     BOOST_WORKAROUND(__MWERKS__,<=0x3003)


### PR DESCRIPTION
Modified type of member variable, will now use the allocator traits's size_type.
This is useful when used in a 32/64bits Boost interprocess shared memory context. Using the previous std::size_t makes the container size different in both architecture, therefore impossible to store in a shared memory.

In most case, this makes no difference because the default allocator's size_type is std::size_t