### PR TITLE
Fix gcc -Wdeprecated-copy

### DIFF
--- a/include/boost/multi_index/detail/ord_index_node.hpp
+++ b/include/boost/multi_index/detail/ord_index_node.hpp
@@ -143,6 +143,8 @@ struct ordered_index_node_compressed_base
   struct color_ref
   {
     color_ref(uintptr_type* r_):r(r_){}
+
+    color_ref(color_ref const& x):r(x.r){}
     
     operator ordered_index_color()const
     {
@@ -168,6 +170,8 @@ struct ordered_index_node_compressed_base
   struct parent_ref
   {
     parent_ref(uintptr_type* r_):r(r_){}
+
+    parent_ref(parent_ref const& x):r(x.r){}
     
     operator pointer()const
     {


### PR DESCRIPTION
Hello,

This patch fixes:

```
/path/include/boost/multi_index/detail/ord_index_node.hpp:357:24: error: implicitly-declared 'constexpr boost::multi_index::detail::ordered_index_node_compressed_base<b
oost::multi_index::detail::null_augment_policy, std::allocator<char> >::parent_ref::parent_ref(const boost::multi_index::detail::ordered_index_node_compressed_base<boost::multi_index::detail::null_augment_policy, std::allocator<char> >::parent_ref&)' is
deprecated [-Werror=deprecated-copy]
  357 |             rotate_left(x,root);
      |             ~~~~~~~~~~~^~~~~~~~
/path/include/boost/multi_index/detail/ord_index_node.hpp:182:17: note: because 'boost::multi_index::detail::ordered_index_node_compressed_base<boost::multi_index::deta
il::null_augment_policy, std::allocator<char> >::parent_ref' has user-provided 'boost::multi_index::detail::ordered_index_node_compressed_base<AugmentPolicy, Allocator>::parent_ref& boost::multi_index::detail::ordered_index_node_compressed_base<AugmentPo
licy, Allocator>::parent_ref::operator=(const boost::multi_index::detail::ordered_index_node_compressed_base<AugmentPolicy, Allocator>::parent_ref&) [with AugmentPolicy = boost::multi_index::detail::null_augment_policy; Allocator = std::allocator<char>]'
  182 |     parent_ref& operator=(const parent_ref& x)
      |
```

Stac