### PR TITLE
Multi index allocator move fix

### DIFF
--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -289,7 +289,7 @@ public:
   }
 
   multi_index_container(BOOST_RV_REF(multi_index_container) x):
-    bfm_allocator(boost::move(x.bfm_allocator::member)),
+    bfm_allocator(x.bfm_allocator::member),
     bfm_header(),
     super(x,detail::do_not_copy_elements_tag()),
     node_count(0)

--- a/test/test_alloc_awareness.cpp
+++ b/test/test_alloc_awareness.cpp
@@ -11,6 +11,7 @@
 #include "test_alloc_awareness.hpp"
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <utility>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/move/core.hpp>
 #include <boost/move/utility_core.hpp>
@@ -113,6 +114,10 @@ void test_allocator_awareness_for()
     c2=c;
     BOOST_TEST(c2.get_allocator().comes_from(Propagate?root1:root2));
     BOOST_TEST(c2==c);
+  }
+  {
+    container t;
+    container c2(std::move(t));
   }
   {
     const bool          element_transfer=Propagate||AlwaysEqual;


### PR DESCRIPTION
Relating to issue #37 

This adds checks to the unit test to show the issue and a potential fix to copy the allocator on multi_index_container move construction - like was done previously on older boost versions.
The unit test checks verify when copying the allocator that the copy is not taken from a moved-from allocator.

Copies are taken in a few places, for example https://github.com/boostorg/multi_index/blob/boost-1.74.0/include/boost/multi_index/random_access_index.hpp#L772 and https://github.com/boostorg/multi_index/blob/boost-1.74.0/include/boost/multi_index/hashed_index.hpp#L710 

The allocator is copied to the indexes anyway so maybe the additional copy does not matter?
Or maybe the indexes should take a reference to the allocator instead of copy?