### PR TITLE
remove TRAVIS_OS_NAME from drone script [ci skip]

### DIFF
--- a/.drone/boost.sh
+++ b/.drone/boost.sh
@@ -2,11 +2,10 @@
 
 set -ex
 export TRAVIS_BUILD_DIR=$(pwd)
+export DRONE_BUILD_DIR=$(pwd)
 export TRAVIS_BRANCH=$DRONE_BRANCH
-export TRAVIS_OS_NAME=${DRONE_JOB_OS_NAME:-linux}
 export VCS_COMMIT_ID=$DRONE_COMMIT
 export GIT_COMMIT=$DRONE_COMMIT
-export DRONE_CURRENT_BUILD_DIR=$(pwd)
 export PATH=~/.local/bin:/usr/local/bin:$PATH
 
 echo '==================================> BEFORE_INSTALL'
@@ -27,7 +26,7 @@ cp -r $TRAVIS_BUILD_DIR/* libs/multi_index
 
 echo '==================================> BEFORE_SCRIPT'
 
-. $DRONE_CURRENT_BUILD_DIR/.drone/before-script.sh
+. $DRONE_BUILD_DIR/.drone/before-script.sh
 
 echo '==================================> SCRIPT'
 
@@ -36,4 +35,4 @@ echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
 
 echo '==================================> AFTER_SUCCESS'
 
-. $DRONE_CURRENT_BUILD_DIR/.drone/after-success.sh
+. $DRONE_BUILD_DIR/.drone/after-success.sh


### PR DESCRIPTION
Small change to drone file. The advantage of removing TRAVIS_OS_NAME from these scripts, and instead setting it in [functions.star](https://github.com/boostorg/boost-ci/blob/master/ci/drone/functions.star) is that it will always be set correctly and not depend on the end-user to configure variables like DRONE_JOB_OS_NAME.