### PR TITLE
Update GitHub Actions CI file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++"
             sources: ""
             llvm_os: ""
@@ -33,7 +34,7 @@ jobs:
             buildtype: "boost"
             packages: "g++-4.4"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "g++"
             sources: ""
@@ -46,7 +47,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-4.6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++"
             sources: ""
             llvm_os: ""
@@ -58,7 +60,7 @@ jobs:
             buildtype: "boost"
             packages: "g++-4.7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "g++-4.7"
             sources: ""
@@ -71,7 +73,7 @@ jobs:
             buildtype: "boost"
             packages: "g++-4.8"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "g++-4.8"
             sources: ""
@@ -84,7 +86,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-4.9"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-4.9"
             sources: ""
             llvm_os: ""
@@ -96,7 +99,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-5"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-5"
             sources: ""
             llvm_os: ""
@@ -108,7 +112,7 @@ jobs:
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "g++-6"
             sources: ""
@@ -121,7 +125,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
             llvm_os: ""
@@ -133,7 +138,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-8"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-8"
             sources: ""
             llvm_os: ""
@@ -145,7 +151,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
             llvm_os: ""
@@ -160,7 +167,7 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++"
             sources: ""
             llvm_os: ""
@@ -172,7 +179,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.3"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "/usr/bin/clang++"
             sources: ""
@@ -185,7 +192,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.4"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "/usr/bin/clang++"
             sources: ""
@@ -198,7 +205,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.5 libstdc++-4.9-dev"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-3.5"
             sources: ""
@@ -211,7 +218,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-3.6"
             sources: ""
@@ -224,7 +231,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-3.7"
             sources: ""
@@ -237,7 +244,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.8 libstdc++-4.9-dev"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-3.8"
             sources: ""
@@ -250,7 +257,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.9 libstdc++-4.9-dev"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-3.9"
             sources: ""
@@ -263,7 +270,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-4.0"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-4.0"
             sources: ""
@@ -276,7 +283,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-5.0"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-5.0"
             sources: ""
@@ -289,7 +296,7 @@ jobs:
             buildtype: "boost"
             packages: "clang-6.0"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
             container: "ubuntu:14.04"
             cxx: "clang++-6.0"
             sources: ""
@@ -302,7 +309,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-7"
             sources: ""
             llvm_os: "xenial"
@@ -314,7 +322,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-7 libstdc++-5-dev"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-7"
             sources: ""
             llvm_os: "xenial"
@@ -328,7 +337,7 @@ jobs:
             buildtype: "boost"
             packages: " libc++-9-dev libc++abi-9-dev"
             packages_to_remove: "libc++-dev libc++abi-dev"
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++-libc++"
             sources: ""
             llvm_os: "xenial"
@@ -340,7 +349,7 @@ jobs:
             buildtype: "boost"
             packages: " libc++-9-dev libc++abi-9-dev"
             packages_to_remove: "libc++-dev libc++abi-dev"
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++-libc++"
             sources: ""
             llvm_os: "xenial"
@@ -361,7 +370,7 @@ jobs:
       - name: If running in container, upgrade packages
         if: matrix.container != ''
         run: |
-            sudo apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev
+            apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev
             sudo apt-add-repository ppa:git-core/ppa
             sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
             python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
@@ -433,7 +442,8 @@ jobs:
           echo '==================================> INSTALL'
 
           cd ..
-          git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
           git submodule update --init
           git rm --ignore-unmatch libs/multi_index/
@@ -515,7 +525,8 @@ jobs:
           echo '==================================> INSTALL'
 
           cd ..
-          git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
           git submodule update --init
           git rm --ignore-unmatch libs/multi_index/


### PR DESCRIPTION
The Ubuntu 16.04 environment is scheduled to be removed from GitHub Actions in September 2021. Migrate those jobs to Docker containers or Ubuntu 18.04. Also, fix a problem with pip package installation on older platforms.