### PR TITLE
count using rank

### DIFF
--- a/doc/reference/rnk_indices.html
+++ b/doc/reference/rnk_indices.html
@@ -177,6 +177,8 @@ distance to it from the beginning of the index. Besides this extension, ranked i
 public interface of ordered indices with the difference, complexity-wise, that <a href="#complexity_signature">deletion</a>
 is done in logarithmic rather than constant time. Also, execution times and memory consumption are
 expected to be poorer due to the internal bookkeeping needed to maintain rank-related information.
+However, the complexity of <code>count</code> is <code>log(n)</code> rather than
+<code>log(n)+count(x)</code>.
 As with ordered indices, ranked indices can be unique (no duplicate elements are allowed)
 or non-unique: either version is associated to a different index specifier, but
 the interface of both index types is the same.
@@ -454,6 +456,8 @@ section</a>. The complexity signature of ranked indices is:
 These complexity guarantees are the same as those of
 <a href="ord_indices.html#complexity_signature">ordered indices</a>
 except for deletion, which is <code>log(n)</code> here and amortized constant there.
+Another difference is that functions <code>count</code> run in <code>log(n)</code> here,
+instead of <code>log(n) + count(x)</code> and <code>log(n) + count(x,comp)</code> there.
 </p>
 
 <h4><a name="instantiation_types">Instantiation types</a></h4>

--- a/example/count_benchmark.cpp
+++ b/example/count_benchmark.cpp
@@ -1,0 +1,160 @@
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/ranked_index.hpp>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <time.h>
+
+using boost::multi_index_container;
+using namespace boost::multi_index;
+
+/* an employee record holds its ID, name and age */
+
+struct employee
+{
+  long long   id;
+  std::string name;
+  int         age;
+
+  employee(long long id_,std::string name_,int age_):id(id_),name(name_),age(age_){}
+};
+
+const int decade=10;
+
+struct smaller_decade
+{
+  bool operator()(int x,int y)const{return x/decade<y/decade;}
+};
+
+struct id{};
+struct name{};
+struct age{};
+
+typedef multi_index_container<
+  employee,
+  indexed_by<
+    ordered_unique<
+      tag<id>,  BOOST_MULTI_INDEX_MEMBER(employee,long long,id)>,
+    ordered_non_unique<
+      tag<name>,BOOST_MULTI_INDEX_MEMBER(employee,std::string,name)>,
+    ordered_non_unique<
+      tag<age>, BOOST_MULTI_INDEX_MEMBER(employee,int,age)> >
+> employee_set;
+
+typedef multi_index_container<
+  employee,
+  indexed_by<
+    ordered_unique<
+      tag<id>,  BOOST_MULTI_INDEX_MEMBER(employee,long long,id)>,
+    ordered_non_unique<
+      tag<name>,BOOST_MULTI_INDEX_MEMBER(employee,std::string,name)>,
+    ranked_non_unique<
+      tag<age>, BOOST_MULTI_INDEX_MEMBER(employee,int,age)> >
+> employee_ranked_set;
+
+int main()
+{
+  std::cout<<"This program benchmarks two implementations, and the duration "
+	     "of its execution may be considerable. Please feel free to stop "
+	     "it at any point or play with the constants.\n";
+
+  for(int variant=0;variant<2;++variant){
+    employee_set es;
+    employee_ranked_set ers;
+    const int max_age=100;
+
+    const int step=(variant==0)?1:decade;
+    const int steps=std::ceil(((double)max_age)/step);
+
+    std::cout<<"\nRunning the test with a comparison predicate differentiating "
+             <<steps<<" groups of values of the index on which we call count "
+             <<"(the actual number of distinct values is "<<max_age<<").\n";
+
+    int last_id1=0,last_id2=0;
+
+    for(int j=-1;j<11;++j){
+      int size=es.size();
+      int people=1000;
+      switch(j){
+	case -1:
+	  people=100;
+	  break;
+	case 0:
+	  people=900;
+	  break;
+	case 10:
+	  people=90000;
+	  break;
+      }
+      std::cout<<"Adding "<<people<<" new people to the multi_index";
+      for(int i=0;i<people;++i){
+	es.insert(employee(last_id1++,"Joe",i%max_age));
+	ers.insert(employee(last_id2++,"Joe",i%max_age));
+	if((10*i)%people==0)
+	  std::cout<<"."<<std::flush;
+      }
+      std::cout<<std::endl;
+
+      for(int iters=max_age;iters<=1000000;iters*=100){
+	std::cout<<"Size "<<std::setw(6)<<es.size()<< ", "
+		 <<std::setw(7)<<iters<<" calls of count()";
+	clock_t start=std::clock();
+	clock_t dur1=start-start;
+	clock_t dur2=start-start;
+
+	const int loops=std::sqrt(iters);
+	for(int k=0;k<loops;++k){
+	  if((10*k)%loops==0)
+	    std::cout<<"."<<std::flush;
+
+	  clock_t start1=std::clock();
+	  for(int i=0;i<iters/loops;++i){
+	    int count=(variant==0)?
+              es.get<age>().count(i%max_age):
+              es.get<age>().count(i%steps*step,smaller_decade());
+	    if(count<1) // To prevent compiler optimisations.
+	      std::cout<<count<<std::endl;
+	  }
+	  clock_t end1=std::clock();
+	  dur1+=end1-start1;
+
+	  clock_t start2=std::clock();
+	  for(int i=0;i<iters/loops;++i){
+	    int count=(variant==0)?
+              ers.get<age>().count(i%max_age):
+              ers.get<age>().count(i%steps*step,smaller_decade());
+	    if(count<1) // To prevent compiler optimisations.
+	      std::cout<<count<<std::endl;
+	  }
+	  clock_t end2=std::clock();
+	  dur2+=end2-start2;
+
+	  // The following is aimed at avoiding the impact of caching.
+	  employee_set::iterator begin_index1=es.get<id>().begin();
+	  int removed_age1=begin_index1->age;
+	  es.get<id>().erase(begin_index1);
+	  es.insert(employee(last_id1++,"Anna",removed_age1));
+
+	  employee_ranked_set::iterator begin_index2=ers.get<id>().begin();
+	  int removed_age2=begin_index2->age;
+	  ers.get<id>().erase(begin_index2);
+	  ers.insert(employee(last_id2++,"Anna",removed_age2));
+	}
+
+	double durMicro1=((double)dur1)/CLOCKS_PER_SEC*1000;
+	std::cout<<std::endl<<std::setw(20)<<durMicro1
+		 <<" ms - time of ordered_index.\n";
+
+	double durMicro2=((double)dur2)/CLOCKS_PER_SEC*1000;
+	std::cout<<std::setw(20)<<durMicro2
+		 <<" ms - time of ranked_index.\n";
+
+	std::cout<<std::fixed<<std::setprecision(2)<<std::setw(20)
+		 <<durMicro1/durMicro2<<" - ratio."<<std::endl;
+      }
+    }
+  }
+  return 0;
+}

--- a/include/boost/multi_index/ranked_index.hpp
+++ b/include/boost/multi_index/ranked_index.hpp
@@ -148,6 +148,19 @@ public:
     return range_rank(lower,upper,dispatch());
   }
 
+  template<typename CompatibleKey>
+  size_type count(const CompatibleKey& x)const
+  {
+    return count(x,this->comp_);
+  }
+
+  template<typename CompatibleKey,typename CompatibleCompare>
+  size_type count(const CompatibleKey& x,const CompatibleCompare& comp)const
+  {
+    std::pair<size_type,size_type> p=this->equal_range_rank(x,comp);
+    return p.second-p.first;
+  }
+
 protected:
   ranked_index(const ranked_index& x):super(x){};
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -45,6 +45,7 @@ test-suite "multi_index" :
     [ run test_composite_key.cpp    test_composite_key_main.cpp    ]
     [ run test_conv_iterators.cpp   test_conv_iterators_main.cpp   ]
     [ run test_copy_assignment.cpp  test_copy_assignment_main.cpp  ]
+    [ run test_count.cpp            test_count_main.cpp            ]
     [ run test_hash_ops.cpp         test_hash_ops_main.cpp         ]
     [ run test_iterators.cpp        test_iterators_main.cpp        ]
     [ run test_key.cpp              test_key_main.cpp

--- a/test/test_all_main.cpp
+++ b/test/test_all_main.cpp
@@ -16,6 +16,7 @@
 #include "test_composite_key.hpp"
 #include "test_conv_iterators.hpp"
 #include "test_copy_assignment.hpp"
+#include "test_count.hpp"
 #include "test_hash_ops.hpp"
 #include "test_iterators.hpp"
 #include "test_key.hpp"
@@ -44,6 +45,7 @@ int main()
   test_composite_key();
   test_conv_iterators();
   test_copy_assignment();
+  test_count();
   test_hash_ops();
   test_iterators();
   test_key();

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -1,0 +1,132 @@
+/* Boost.MultiIndex count test.
+ *
+ * Copyright 2022 Damian Sawicki.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#include "test_count.hpp"
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <vector>
+#include <set>
+#include "pre_multi_index.hpp"
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/ranked_index.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+using namespace boost::multi_index;
+
+struct employee
+{
+  int   id;
+  int   age;
+
+  employee(int id_,int age_):id(id_),age(age_){}
+};
+
+struct id{};
+struct age_o{};
+struct age_r{};
+
+typedef multi_index_container<
+  employee,
+  indexed_by<
+    ordered_unique<
+      tag<id>,    BOOST_MULTI_INDEX_MEMBER(employee,int,id)>,
+    ordered_non_unique<
+      tag<age_o>, BOOST_MULTI_INDEX_MEMBER(employee,int,age)>,
+    ranked_non_unique<
+      tag<age_r>, BOOST_MULTI_INDEX_MEMBER(employee,int,age)> >
+> employee_set;
+
+void test_count_hardcoded()
+{
+  employee_set es;
+  int last_id=0;
+  for(int i=1;i<=10;++i){
+    for(int j=0;j<2*i;++j){
+      es.insert(employee(last_id++,40+i));
+    }
+  }
+  for(uint i=0;i<=10;++i){
+    BOOST_TEST(es.get<age_o>().count(40+i)==2*i);
+    BOOST_TEST(es.get<age_r>().count(40+i)==2*i);
+  }
+  es.insert(employee(last_id++,60));
+  for(int i=0;i<40;++i){
+    BOOST_TEST(es.get<age_o>().count(i)==0);
+    BOOST_TEST(es.get<age_r>().count(i)==0);
+  }
+  for(int i=51;i<60;++i){
+    BOOST_TEST(es.get<age_o>().count(i)==0);
+    BOOST_TEST(es.get<age_r>().count(i)==0);
+  }
+  BOOST_TEST(es.get<age_o>().count(60)==1);
+  BOOST_TEST(es.get<age_r>().count(60)==1);
+  for(int i=61;i<100;++i){
+    BOOST_TEST(es.get<age_o>().count(i)==0);
+    BOOST_TEST(es.get<age_r>().count(i)==0);
+  }
+}
+
+const int decade=10;
+struct smaller_decade
+{
+  bool operator()(int x,int y)const{return x/decade<y/decade;}
+};
+
+void test_count_random()
+{
+  const int max_age=100; // Should be a multiple of decade.
+  int numbers_of_inserts[]={10,100,1000};
+  // Relatively frequent vs unlikely failed insert:
+  int id_ranges[]={1000,1000000000};
+  const int random_loops=10;
+  srand(time(NULL));
+  const int max_x=sizeof(id_ranges)/sizeof(id_ranges[0]);
+  for(int x=0;x<max_x;++x){
+    int id_range=id_ranges[x];
+    const int max_y=sizeof(numbers_of_inserts)/sizeof(numbers_of_inserts[0]);
+    for(int y=0;y<max_y;++y){
+      int number_of_inserts=numbers_of_inserts[y];
+      for(uint i=0;i<random_loops;++i){
+        employee_set random_set;
+        std::set<int> used_ids;
+        uint counts[max_age]={};
+        for(int j=0;j<number_of_inserts;++j){
+          int random_id=rand()%id_range;
+          int random_age=rand()%max_age;
+          std::pair<employee_set::iterator,bool> result=
+            random_set.insert(employee(random_id,random_age));
+          BOOST_TEST(result.second!=used_ids.count(random_id));
+          if(result.second){
+            used_ids.insert(random_id);
+            ++counts[random_age];
+          }
+        }
+        for(int k=0;k<max_age;++k){
+          BOOST_TEST(counts[k]==random_set.get<age_r>().count(k));
+          BOOST_TEST(counts[k]==random_set.get<age_o>().count(k));
+          uint group=0;
+          int decade_start=k/decade*decade;
+          for(int j=decade_start;j<decade_start+decade;++j)
+            group+=counts[j];
+          BOOST_TEST(group==random_set.get<age_r>().count(k,smaller_decade()));
+          BOOST_TEST(group==random_set.get<age_o>().count(k,smaller_decade()));
+        }
+      }
+    }
+  }
+}
+
+void test_count()
+{
+  test_count_hardcoded();
+  test_count_random();
+}

--- a/test/test_count.hpp
+++ b/test/test_count.hpp
@@ -1,0 +1,12 @@
+/* Boost.MultiIndex count test.
+ *
+ * Copyright 2003-2008 Joaquin M Lopez Munoz.
+ * Copyright 2022 Damian Sawicki.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+void test_count();

--- a/test/test_count_main.cpp
+++ b/test/test_count_main.cpp
@@ -1,0 +1,19 @@
+/* Boost.MultiIndex count test.
+ *
+ * Copyright 2003-2008 Joaquin M Lopez Munoz.
+ * Copyright 2022 Damian Sawicki.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#include <boost/detail/lightweight_test.hpp>
+#include "test_count.hpp"
+
+int main()
+{
+  test_count();
+  return boost::report_errors();
+}


### PR DESCRIPTION
**Purpose.** The purpose of this contribution is to replace in `ranked_index` the ordinary implementation of `count(x)` and `count(x,comp)` from `ordered_index` with an implementation using rank, which reduces the time complexity from respectively `log(n)+count(x)` and `log(n)+count(x,comp)` down to `log(n)`.

**Explanation.** The implementation from `ordered_index` uses `std::distance`, which travels linearly between the beginning and end of the range. When `count(x)`/`count(x,comp)` is comparable with `n`, the computational cost is high. For `ranked_index`, one can subtract the corresponding values of rank instead.

**Motivation.** As opposed to `contains`, the usage of methods called `count`  is best justified when the return values can be larger than `1`. Example use cases when `count(x)` is large include boolean indices, but also restricted numeric indices like the age of people (particularly for special social groups like university students) or even strings like names. Another use case is when a developer is interested in grouping values of an index according to some comparison predicate. For example, one can take the already restricted index of people's ages and group its values into age groups `0..9`, `10..19` etc. with a comparison predicate `comp` comparing `age/10`.

**Changes in the repository.** The additions of this pull request consist of

- the new implementation of `count(x)` and `count(x,comp)` in `include/boost/multi_index/ranked_index.hpp`;
- regression tests comparing the new `count` functions in `ranked_index` with those in `ordered_index` (added to `test/Jamfile.v2` and `test/test_all_main.cpp`);
- a benchmark in `example/count_benchmark.cpp` showing that the new implementation performs similarly to the implementation in `ordered_index` when `count(x,comp) <= 1` and highly outperforms it for large values of `count(x,comp)` (see the respective commit message for a summary of results of running benchmark on my machine);
- an update of documentation with the new complexity of `count(x)` and `count(x,comp)` for `ranked_index`.

**Tests.** The code successfully passes the existing tests and the newly added tests of the proposed changes, with the exception of compilation errors in job 20 (`posix (TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03, Job 20, boost, clang-5.0, ubuntu-20.04...`) identical to those (https://drone.cpp.al/boostorg/multi_index/89/21/2) occurring for the branch `master` of `boostorg/multi_index` 