### PR TITLE
refactor use core/ref.hpp over ref.hpp

### DIFF
--- a/include/boost/multi_index/composite_key.hpp
+++ b/include/boost/multi_index/composite_key.hpp
@@ -32,7 +32,7 @@
 #include <functional>
 
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #endif
 
 #if !defined(BOOST_NO_SFINAE)

--- a/include/boost/multi_index/detail/ord_index_impl.hpp
+++ b/include/boost/multi_index/detail/ord_index_impl.hpp
@@ -45,6 +45,7 @@
 #include <boost/call_traits.hpp>
 #include <boost/core/addressof.hpp>
 #include <boost/core/no_exceptions_support.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/foreach_fwd.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
@@ -70,7 +71,6 @@
 #include <boost/multi_index/detail/value_compare.hpp>
 #include <boost/multi_index/detail/vartempl_support.hpp>
 #include <boost/multi_index/detail/ord_index_impl_fwd.hpp>
-#include <boost/ref.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <utility>

--- a/test/test_key_extractors.cpp
+++ b/test/test_key_extractors.cpp
@@ -11,10 +11,10 @@
 #include "test_key_extractors.hpp"
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/core/ref.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include "pre_multi_index.hpp"
 #include <boost/multi_index/key_extractors.hpp>
-#include <boost/ref.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <list>
 

--- a/test/test_rearrange.cpp
+++ b/test/test_rearrange.cpp
@@ -13,6 +13,7 @@
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <algorithm>
 #include <iterator>
+#include <boost/core/ref.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include "pre_multi_index.hpp"
 #include <boost/multi_index_container.hpp>
@@ -20,7 +21,6 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/next_prior.hpp>
 #include <boost/preprocessor/seq/enum.hpp>
-#include <boost/ref.hpp>
 #include <vector>
 
 using namespace boost::multi_index;


### PR DESCRIPTION
The later has been deprecated:
```cpp

// The header file at this path is deprecated;
// use boost/core/ref.hpp instead.

```