### PR TITLE
refactor: use core/enable_if over utility/enable_if

### DIFF
--- a/include/boost/multi_index/composite_key.hpp
+++ b/include/boost/multi_index/composite_key.hpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/core/enable_if.hpp>
 #include <boost/functional/hash_fwd.hpp>
 #include <boost/multi_index/detail/access_specifier.hpp>
 #include <boost/mpl/eval_if.hpp>
@@ -28,7 +29,6 @@
 #include <boost/static_assert.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <functional>
 
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)

--- a/include/boost/multi_index/detail/is_transparent.hpp
+++ b/include/boost/multi_index/detail/is_transparent.hpp
@@ -41,6 +41,7 @@ struct is_transparent:mpl::true_{};
     !defined(BOOST_NO_CXX11_DECLTYPE)&& \
     (defined(BOOST_NO_CXX11_FINAL)||defined(BOOST_IS_FINAL))
 
+#include <boost/core/enable_if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/mpl/or.hpp>
@@ -51,7 +52,6 @@ struct is_transparent:mpl::true_{};
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/utility/declval.hpp>
-#include <boost/utility/enable_if.hpp>
 
 namespace boost{
 

--- a/include/boost/multi_index/detail/node_handle.hpp
+++ b/include/boost/multi_index/detail/node_handle.hpp
@@ -26,9 +26,9 @@
 #include <new>
 
 #if !defined(BOOST_NO_SFINAE)
+#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
 #endif
 
 namespace boost{

--- a/include/boost/multi_index/global_fun.hpp
+++ b/include/boost/multi_index/global_fun.hpp
@@ -14,13 +14,13 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/core/enable_if.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #if !defined(BOOST_NO_SFINAE)
 #include <boost/type_traits/is_convertible.hpp>

--- a/include/boost/multi_index/identity.hpp
+++ b/include/boost/multi_index/identity.hpp
@@ -14,12 +14,12 @@
 #endif
 
 #include <boost/config.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/multi_index/identity_fwd.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #if !defined(BOOST_NO_SFINAE)
 #include <boost/type_traits/is_convertible.hpp>

--- a/include/boost/multi_index/mem_fun.hpp
+++ b/include/boost/multi_index/mem_fun.hpp
@@ -14,9 +14,9 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/core/enable_if.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/remove_reference.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #if !defined(BOOST_NO_SFINAE)
 #include <boost/type_traits/is_convertible.hpp>

--- a/include/boost/multi_index/member.hpp
+++ b/include/boost/multi_index/member.hpp
@@ -14,9 +14,9 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/core/enable_if.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_const.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <cstddef>
 
 #if !defined(BOOST_NO_SFINAE)


### PR DESCRIPTION
The later is deprecated:
```cpp
// The header file at this path is deprecated;
// use boost/core/enable_if.hpp instead.

#include <boost/core/enable_if.hpp>
```