### PR TITLE
Minor include refactors

### DIFF
--- a/include/boost/multi_index/composite_key.hpp
+++ b/include/boost/multi_index/composite_key.hpp
@@ -14,8 +14,8 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/container_hash/hash_fwd.hpp>
 #include <boost/core/enable_if.hpp>
-#include <boost/functional/hash_fwd.hpp>
 #include <boost/multi_index/detail/access_specifier.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>

--- a/include/boost/multi_index/detail/hash_index_args.hpp
+++ b/include/boost/multi_index/detail/hash_index_args.hpp
@@ -14,7 +14,7 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
-#include <boost/functional/hash.hpp>
+#include <boost/container_hash/hash.hpp>
 #include <boost/mpl/aux_/na.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>

--- a/include/boost/multi_index/detail/is_transparent.hpp
+++ b/include/boost/multi_index/detail/is_transparent.hpp
@@ -45,13 +45,13 @@ struct is_transparent:mpl::true_{};
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/mpl/or.hpp>
+#include <boost/type_traits/declval.hpp>
 #include <boost/type_traits/function_traits.hpp>
 #include <boost/type_traits/is_class.hpp>
 #include <boost/type_traits/is_final.hpp>
 #include <boost/type_traits/is_function.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
-#include <boost/utility/declval.hpp>
 
 namespace boost{
 


### PR DESCRIPTION
This refactor just replaces includes, with more direct includes. In all cases, we are swapping a header that includes an additional header, for just the additional header, i.e `boost/utility/declval.hpp`, for `boost/type_traits/declval.hpp`.