### PR TITLE
Remove dependency on Boost.ForEach from CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(boost_multi_index
     Boost::config
     Boost::container_hash
     Boost::core
-    Boost::foreach
     Boost::integer
     Boost::iterator
     Boost::move


### PR DESCRIPTION
No public headers depend on Boost.ForEach headers, so the dependency in CMakeLists.txt is not needed.

This dependency causes problems in downstream CI runs because boostdep does not find the dependency on Boost.ForEach from public headers and does not checkout Boost.ForEach git repo. This causes CMake errors because it cannot resolve the Boost::foreach target.