### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(boost_multi_index
     Boost::mp11
     Boost::preprocessor
     Boost::smart_ptr
-    Boost::static_assert
     Boost::throw_exception
     Boost::tuple
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/mp11//boost_mp11
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.