### PR TITLE
[bug] Fix severe performance bug caused by usage of `float`

### DIFF
--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -1432,7 +1432,11 @@ private:
     if(n>max_load){
       size_type bc =(std::numeric_limits<size_type>::max)();
       float     fbc=1.0f+static_cast<float>(n)/mlf;
-      if(bc>fbc)bc =(std::max)(static_cast<size_type>(fbc),bucket_count()+1);
+      if(bc>fbc){
+        bc =(std::max)(
+          static_cast<size_type>(fbc),
+          static_cast<size_type>(bucket_count()+1));
+      }
       unchecked_rehash(bc);
     }
   }

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -710,10 +710,10 @@ public:
 
   /* hash policy */
 
-  float load_factor()const BOOST_NOEXCEPT
-    {return static_cast<float>(size())/bucket_count();}
-  float max_load_factor()const BOOST_NOEXCEPT{return mlf;}
-  void  max_load_factor(float z){mlf=z;calculate_max_load();}
+  double load_factor()const BOOST_NOEXCEPT
+    {return static_cast<double>(size())/bucket_count();}
+  double max_load_factor()const BOOST_NOEXCEPT{return mlf;}
+  void  max_load_factor(double z){mlf=z;calculate_max_load();}
 
   void rehash(size_type n)
   {
@@ -721,7 +721,7 @@ public:
     if(size()<=max_load&&n<=bucket_count())return;
 
     size_type bc =(std::numeric_limits<size_type>::max)();
-    float     fbc=1.0f+static_cast<float>(size())/mlf;
+    double     fbc=1.0f+static_cast<double>(size())/mlf;
     if(bc>fbc){
       bc=static_cast<size_type>(fbc);
       if(bc<n)bc=n;
@@ -731,7 +731,7 @@ public:
 
   void reserve(size_type n)
   {
-    rehash(static_cast<size_type>(std::ceil(static_cast<float>(n)/mlf)));
+    rehash(static_cast<size_type>(std::ceil(static_cast<double>(n)/mlf)));
   }
 
 protected:
@@ -1422,7 +1422,7 @@ private:
 
   void calculate_max_load()
   {
-    float fml=mlf*static_cast<float>(bucket_count());
+    double fml=mlf*static_cast<double>(bucket_count());
     max_load=(std::numeric_limits<size_type>::max)();
     if(max_load>fml)max_load=static_cast<size_type>(fml);
   }
@@ -1431,7 +1431,7 @@ private:
   {
     if(n>max_load){
       size_type bc =(std::numeric_limits<size_type>::max)();
-      float     fbc=1.0f+static_cast<float>(n)/mlf;
+      double     fbc=1.0f+static_cast<double>(n)/mlf;
       if(bc>fbc)bc =static_cast<size_type>(fbc);
       unchecked_rehash(bc);
     }
@@ -1735,7 +1735,7 @@ private:
   hasher                       hash_;
   key_equal                    eq_;
   bucket_array_type            buckets;
-  float                        mlf;
+  double                        mlf;
   size_type                    max_load;
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -1432,7 +1432,7 @@ private:
     if(n>max_load){
       size_type bc =(std::numeric_limits<size_type>::max)();
       float     fbc=1.0f+static_cast<float>(n)/mlf;
-      if(bc>fbc)bc =static_cast<size_type>(fbc);
+      if(bc>fbc)bc =(std::max)(static_cast<size_type>(fbc),bucket_count()+1);
       unchecked_rehash(bc);
     }
   }

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -710,10 +710,10 @@ public:
 
   /* hash policy */
 
-  double load_factor()const BOOST_NOEXCEPT
-    {return static_cast<double>(size())/bucket_count();}
-  double max_load_factor()const BOOST_NOEXCEPT{return mlf;}
-  void  max_load_factor(double z){mlf=z;calculate_max_load();}
+  float load_factor()const BOOST_NOEXCEPT
+    {return static_cast<float>(size())/bucket_count();}
+  float max_load_factor()const BOOST_NOEXCEPT{return mlf;}
+  void  max_load_factor(float z){mlf=z;calculate_max_load();}
 
   void rehash(size_type n)
   {
@@ -721,7 +721,7 @@ public:
     if(size()<=max_load&&n<=bucket_count())return;
 
     size_type bc =(std::numeric_limits<size_type>::max)();
-    double    fbc=1.0f+static_cast<double>(size())/mlf;
+    float     fbc=1.0f+static_cast<float>(size())/mlf;
     if(bc>fbc){
       bc=static_cast<size_type>(fbc);
       if(bc<n)bc=n;
@@ -731,7 +731,7 @@ public:
 
   void reserve(size_type n)
   {
-    rehash(static_cast<size_type>(std::ceil(static_cast<double>(n)/mlf)));
+    rehash(static_cast<size_type>(std::ceil(static_cast<float>(n)/mlf)));
   }
 
 protected:
@@ -1422,7 +1422,7 @@ private:
 
   void calculate_max_load()
   {
-    double fml=mlf*static_cast<double>(bucket_count());
+    float fml=mlf*static_cast<float>(bucket_count());
     max_load=(std::numeric_limits<size_type>::max)();
     if(max_load>fml)max_load=static_cast<size_type>(fml);
   }
@@ -1431,7 +1431,7 @@ private:
   {
     if(n>max_load){
       size_type bc =(std::numeric_limits<size_type>::max)();
-      double    fbc=1.0f+static_cast<double>(n)/mlf;
+      float     fbc=1.0f+static_cast<float>(n)/mlf;
       if(bc>fbc)bc =static_cast<size_type>(fbc);
       unchecked_rehash(bc);
     }
@@ -1735,7 +1735,7 @@ private:
   hasher                       hash_;
   key_equal                    eq_;
   bucket_array_type            buckets;
-  double                       mlf;
+  float                        mlf;
   size_type                    max_load;
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -721,7 +721,7 @@ public:
     if(size()<=max_load&&n<=bucket_count())return;
 
     size_type bc =(std::numeric_limits<size_type>::max)();
-    double     fbc=1.0f+static_cast<double>(size())/mlf;
+    double    fbc=1.0f+static_cast<double>(size())/mlf;
     if(bc>fbc){
       bc=static_cast<size_type>(fbc);
       if(bc<n)bc=n;
@@ -1431,7 +1431,7 @@ private:
   {
     if(n>max_load){
       size_type bc =(std::numeric_limits<size_type>::max)();
-      double     fbc=1.0f+static_cast<double>(n)/mlf;
+      double    fbc=1.0f+static_cast<double>(n)/mlf;
       if(bc>fbc)bc =static_cast<size_type>(fbc);
       unchecked_rehash(bc);
     }
@@ -1735,7 +1735,7 @@ private:
   hasher                       hash_;
   key_equal                    eq_;
   bucket_array_type            buckets;
-  double                        mlf;
+  double                       mlf;
   size_type                    max_load;
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)


### PR DESCRIPTION
# Intro
There's a bug when using hashed_index with large amounts of elements. 
It leads to the index being rehashed on multiple subsequent inserts at specific points 
after about 50M elements, which ruins the amortized constant complexity of insert. 
I discovered this when using `boost::flyweight` with `hashed_factory`, and unfortunately, 
this rendered it unusuable (since we had 400M+ unique elements to insert).

# The bug: 
Internal functions in `hashed_index.hpp` use type float when calculating bucket count. 
From some point, float's mantissa is not wide enough to represent number of elements, 
and starts rounding to the nearest representable value, which is a problem here:
```
  void reserve_for_insert(size_type n)
  {
    if(n>max_load){
      size_type bc =(std::numeric_limits<size_type>::max)();
      float     fbc=1.0f+static_cast<float>(n)/mlf;
      if(bc>fbc)bc =static_cast<size_type>(fbc);
      unchecked_rehash(bc);
    }
  }
```

The example program below "observes" when rehashes happen by measuring insert time:
```
#include <boost/multi_index_container.hpp>
#include <boost/multi_index/hashed_index.hpp>

#include <iostream>
#include <chrono>
#include <format>

using namespace boost::multi_index;

using time_unit = std::chrono::milliseconds;

void note_time(time_unit time, size_t container_size)
{
    static unsigned long max = 0;
    const double tol = 0.25;        // we assume that if an insert takes at least 25 % of the known maximum time,
                                    // then it was due to rehashing
    const unsigned long ms = std::chrono::duration_cast<std::chrono::milliseconds>(time).count();
    if (ms > max)
    {
        max = ms;
    }
    // don't print results below 1ms
    if (ms >= 1 && ms >= max * tol)
    {
        std::cout << std::format("container size: {}, insert time: {} ms\n", container_size, ms);
    }
}

int main()
{
    using container_t = multi_index_container<
        int,
        indexed_by<
            hashed_unique<identity<int>>
        >
    >;

    container_t c;

    for (int i = 0; i < 405'000'000; ++i) {
        using clock = std::chrono::steady_clock;
        auto t0 = clock::now();
        c.insert(i);
        auto t1 = clock::now();
        auto duration = t1 - t0;
        note_time(std::chrono::duration_cast<time_unit>(duration), c.size());
    }
}
```

output when I run it with hashed_index.cpp as it is:
---
container size: 49158, insert time: 1 ms
container size: 98318, insert time: 3 ms
container size: 196614, insert time: 8 ms
container size: 393242, insert time: 9 ms
container size: 786434, insert time: 18 ms
container size: 1572870, insert time: 36 ms
container size: 3145740, insert time: 77 ms
container size: 6291470, insert time: 150 ms
container size: 12582918, insert time: 292 ms
container size: 25165845, insert time: 587 ms
_container size: 50331653, insert time: 1020 ms_
**container size: 50331654, insert time: 1178 ms**
container size: 100663321, insert time: 2364 ms
_container size: 201326609, insert time: 4037 ms_
**container size: 201326610, insert time: 4049 ms
container size: 201326611, insert time: 4046 ms
container size: 201326612, insert time: 4041 ms
container size: 201326613, insert time: 5151 ms
container size: 201326614, insert time: 4505 ms
container size: 201326615, insert time: 4121 ms
container size: 201326616, insert time: 4736 ms**
_container size: 402653185, insert time: 10695 ms_
**container size: 402653186, insert time: 10467 ms
container size: 402653187, insert time: 9885 ms
container size: 402653188, insert time: 9453 ms
container size: 402653189, insert time: 9682 ms
container size: 402653190, insert time: 9782 ms
container size: 402653191, insert time: 8572 ms
container size: 402653192, insert time: 8470 ms
container size: 402653193, insert time: 9243 ms
container size: 402653194, insert time: 8909 ms
container size: 402653195, insert time: 8564 ms
container size: 402653196, insert time: 8632 ms
container size: 402653197, insert time: 9015 ms
container size: 402653198, insert time: 11286 ms
container size: 402653199, insert time: 8990 ms
container size: 402653200, insert time: 8911 ms
container size: 402653201, insert time: 15674 ms**

as we can see, the container rehashes on multiple subsequent events.

output when I run it with the fix (replacing all floats with doubles):
---
```
container size: 49158, insert time: 1 ms
container size: 98318, insert time: 2 ms
container size: 196614, insert time: 5 ms
container size: 393242, insert time: 10 ms
container size: 786434, insert time: 18 ms
container size: 1572870, insert time: 36 ms
container size: 3145740, insert time: 73 ms
container size: 6291470, insert time: 146 ms
container size: 12582918, insert time: 293 ms
container size: 25165844, insert time: 626 ms
container size: 50331654, insert time: 1167 ms
container size: 100663320, insert time: 2314 ms
container size: 201326612, insert time: 4636 ms
container size: 402653190, insert time: 11913 ms
```