### PR TITLE
avoided bogus unitialized warnings in GCC 16.1, plus additional warning silencing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,18 @@ jobs:
             os: ubuntu-24.04
             install: g++-14-multilib
             address-model: 32,64
+          - toolset: gcc-15
+            cxxstd: "11,14,17,20,23,2c"
+            container: ubuntu:26.04
+            os: ubuntu-latest
+            install: g++-15-multilib
+            address-model: 32,64
+          - toolset: gcc-16
+            cxxstd: "11,14,17,20,23,2c"
+            container: ubuntu:26.04
+            os: ubuntu-latest
+            install: g++-16-multilib
+            address-model: 32,64
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "11,14"

--- a/include/boost/multi_index/detail/header_holder.hpp
+++ b/include/boost/multi_index/detail/header_holder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2022 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -32,13 +32,31 @@ namespace detail{
 template<typename NodeTypePtr,typename Final>
 struct header_holder:private noncopyable
 {
-  header_holder():member(final().allocate_node()){}
-  ~header_holder(){final().deallocate_node(&*member);}
+  header_holder()
+  {
+    new (&spc) NodeTypePtr(final().allocate_node());
+  }
 
-  NodeTypePtr member;
+  ~header_holder()
+  {
+    final().deallocate_node(&*member());
+    member().~NodeTypePtr();
+  }
+
+  const NodeTypePtr& member()const noexcept
+  {
+    return *static_cast<const NodeTypePtr*>(static_cast<void const*>(&spc));
+  }
+
+  NodeTypePtr& member()noexcept
+  {
+    return *static_cast<NodeTypePtr*>(static_cast<void*>(&spc));
+  }
 
 private:
   Final& final(){return *static_cast<Final*>(this);}
+
+  alignas(NodeTypePtr) unsigned char spc[sizeof(NodeTypePtr)];
 };
 
 } /* namespace multi_index::detail */

--- a/include/boost/multi_index/detail/header_holder.hpp
+++ b/include/boost/multi_index/detail/header_holder.hpp
@@ -45,12 +45,13 @@ struct header_holder:private noncopyable
 
   const NodeTypePtr& member()const noexcept
   {
-    return *static_cast<const NodeTypePtr*>(static_cast<void const*>(&spc));
+    return *reinterpret_cast<const NodeTypePtr*>(
+      static_cast<void const*>(&spc));
   }
 
   NodeTypePtr& member()noexcept
   {
-    return *static_cast<NodeTypePtr*>(static_cast<void*>(&spc));
+    return *reinterpret_cast<NodeTypePtr*>(static_cast<void*>(&spc));
   }
 
 private:

--- a/include/boost/multi_index/detail/header_holder.hpp
+++ b/include/boost/multi_index/detail/header_holder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2026 Joaquin M Lopez Munoz.
+/* Copyright 2003-2022 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -32,32 +32,13 @@ namespace detail{
 template<typename NodeTypePtr,typename Final>
 struct header_holder:private noncopyable
 {
-  header_holder()
-  {
-    new (&spc) NodeTypePtr(final().allocate_node());
-  }
+  header_holder():member(final().allocate_node()){}
+  ~header_holder(){final().deallocate_node(&*member);}
 
-  ~header_holder()
-  {
-    final().deallocate_node(&*member());
-    member().~NodeTypePtr();
-  }
-
-  const NodeTypePtr& member()const noexcept
-  {
-    return *reinterpret_cast<const NodeTypePtr*>(
-      static_cast<void const*>(&spc));
-  }
-
-  NodeTypePtr& member()noexcept
-  {
-    return *reinterpret_cast<NodeTypePtr*>(static_cast<void*>(&spc));
-  }
+  NodeTypePtr member;
 
 private:
   Final& final(){return *static_cast<Final*>(this);}
-
-  alignas(NodeTypePtr) unsigned char spc[sizeof(NodeTypePtr)];
 };
 
 } /* namespace multi_index::detail */

--- a/include/boost/multi_index/detail/index_base.hpp
+++ b/include/boost/multi_index/detail/index_base.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -85,10 +85,16 @@ private:
   typedef allocator_size_type_t<Allocator>    size_type;
 
 protected:
-  explicit index_base(const ctor_args_list&,const Allocator&){}
+  explicit index_base(
+    const ctor_args_list&,const Allocator&,index_node_type*){}
 
   index_base(
     const index_base<Value,IndexSpecifierList,Allocator>&,
+    const Allocator&,index_node_type*){}
+
+  index_base(
+    const index_base<Value,IndexSpecifierList,Allocator>&,
+    const Allocator&,index_node_type*,
     do_not_copy_elements_tag)
   {}
 

--- a/include/boost/multi_index/detail/ord_index_impl.hpp
+++ b/include/boost/multi_index/detail/ord_index_impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -707,8 +707,10 @@ public:
   }
 
 protected:
-  ordered_index_impl(const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list.get_tail(),al),
+  ordered_index_impl(
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list.get_tail(),al,h),
     key(tuples::get<0>(args_list.get_head())),
     comp_(tuples::get<1>(args_list.get_head()))
 
@@ -722,8 +724,9 @@ protected:
 
   ordered_index_impl(
     const ordered_index_impl<
-      KeyFromValue,Compare,SuperMeta,TagList,Category,AugmentPolicy>& x):
-    super(x),
+      KeyFromValue,Compare,SuperMeta,TagList,Category,AugmentPolicy>& x,
+    const allocator_type& al,index_node_type* h):
+    super(x,al,h),
     key(x.key),
     comp_(x.comp_)
 
@@ -740,8 +743,9 @@ protected:
   ordered_index_impl(
      const ordered_index_impl<
        KeyFromValue,Compare,SuperMeta,TagList,Category,AugmentPolicy>& x,
+     const allocator_type& al,index_node_type* h,
      do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag()),
+    super(x,al,h,do_not_copy_elements_tag()),
     key(x.key),
     comp_(x.comp_)
 
@@ -1512,6 +1516,10 @@ class ordered_index:
         SuperMeta,TagList,Category,AugmentPolicy
       >
     >::type                                       super;
+
+protected:
+  typedef typename super::index_node_type         index_node_type;
+
 public:
   typedef typename super::ctor_args_list          ctor_args_list;
   typedef typename super::allocator_type          allocator_type;
@@ -1537,13 +1545,18 @@ public:
 
 protected:
   ordered_index(
-    const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list,al){}
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list,al,h){}
 
-  ordered_index(const ordered_index& x):super(x){}
+  ordered_index(
+    const ordered_index& x,const allocator_type& al,index_node_type* h):
+    super(x,al,h){}
 
-  ordered_index(const ordered_index& x,do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag()){}
+  ordered_index(
+    const ordered_index& x,const allocator_type& al,index_node_type* h,
+    do_not_copy_elements_tag):
+    super(x,al,h,do_not_copy_elements_tag()){}
 };
 
 #if defined(BOOST_MSVC)

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -742,7 +742,7 @@ protected:
     key(tuples::get<1>(args_list.get_head())),
     hash_(tuples::get<2>(args_list.get_head())),
     eq_(tuples::get<3>(args_list.get_head())),
-    buckets(al,header()->impl(),tuples::get<0>(args_list.get_head())),
+    buckets(al,h->impl(),tuples::get<0>(args_list.get_head())),
     mlf(1.0f)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
@@ -760,7 +760,7 @@ protected:
     key(x.key),
     hash_(x.hash_),
     eq_(x.eq_),
-    buckets(x.get_allocator(),header()->impl(),x.buckets.size()),
+    buckets(al,h->impl(),x.buckets.size()),
     mlf(x.mlf),
     max_load(x.max_load)
 
@@ -782,7 +782,7 @@ protected:
     key(x.key),
     hash_(x.hash_),
     eq_(x.eq_),
-    buckets(x.get_allocator(),h->impl(),0),
+    buckets(al,h->impl(),0),
     mlf(1.0f)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)

--- a/include/boost/multi_index/hashed_index.hpp
+++ b/include/boost/multi_index/hashed_index.hpp
@@ -735,8 +735,10 @@ public:
   }
 
 protected:
-  hashed_index(const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list.get_tail(),al),
+  hashed_index(
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list.get_tail(),al,h),
     key(tuples::get<1>(args_list.get_head())),
     hash_(tuples::get<2>(args_list.get_head())),
     eq_(tuples::get<3>(args_list.get_head())),
@@ -752,8 +754,9 @@ protected:
   }
 
   hashed_index(
-    const hashed_index<KeyFromValue,Hash,Pred,SuperMeta,TagList,Category>& x):
-    super(x),
+    const hashed_index<KeyFromValue,Hash,Pred,SuperMeta,TagList,Category>& x,
+    const allocator_type& al,index_node_type* h):
+    super(x,al,h),
     key(x.key),
     hash_(x.hash_),
     eq_(x.eq_),
@@ -773,12 +776,13 @@ protected:
 
   hashed_index(
     const hashed_index<KeyFromValue,Hash,Pred,SuperMeta,TagList,Category>& x,
+    const allocator_type& al,index_node_type* h,
     do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag()),
+    super(x,al,h,do_not_copy_elements_tag()),
     key(x.key),
     hash_(x.hash_),
     eq_(x.eq_),
-    buckets(x.get_allocator(),header()->impl(),0),
+    buckets(x.get_allocator(),h->impl(),0),
     mlf(1.0f)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)

--- a/include/boost/multi_index/random_access_index.hpp
+++ b/include/boost/multi_index/random_access_index.hpp
@@ -744,7 +744,7 @@ protected:
     const ctor_args_list& args_list,
     const allocator_type& al,index_node_type* h):
     super(args_list.get_tail(),al,h),
-    ptrs(al,header()->impl(),0)
+    ptrs(al,h->impl(),0)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)

--- a/include/boost/multi_index/random_access_index.hpp
+++ b/include/boost/multi_index/random_access_index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -741,8 +741,9 @@ public:
     
 protected:
   random_access_index(
-    const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list.get_tail(),al),
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list.get_tail(),al,h),
     ptrs(al,header()->impl(),0)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
@@ -752,9 +753,11 @@ protected:
   {
   }
 
-  random_access_index(const random_access_index<SuperMeta,TagList>& x):
-    super(x),
-    ptrs(x.get_allocator(),header()->impl(),x.size())
+  random_access_index(
+    const random_access_index<SuperMeta,TagList>& x,
+    const allocator_type& al,index_node_type* h):
+    super(x,al,h),
+    ptrs(al,h->impl(),x.size())
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)
@@ -766,9 +769,11 @@ protected:
   }
 
   random_access_index(
-    const random_access_index<SuperMeta,TagList>& x,do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag()),
-    ptrs(x.get_allocator(),header()->impl(),0)
+    const random_access_index<SuperMeta,TagList>& x,
+    const allocator_type& al,index_node_type* h,
+    do_not_copy_elements_tag):
+    super(x,al,h,do_not_copy_elements_tag()),
+    ptrs(al,h->impl(),0)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)

--- a/include/boost/multi_index/ranked_index.hpp
+++ b/include/boost/multi_index/ranked_index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -165,14 +165,19 @@ public:
   }
 
 protected:
-  ranked_index(const ranked_index& x):super(x){};
-
-  ranked_index(const ranked_index& x,do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag()){};
+  ranked_index(
+    const ranked_index& x,const allocator_type& al,index_node_type* h):
+    super(x,al,h){};
 
   ranked_index(
-    const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list,al){}
+    const ranked_index& x,const allocator_type& al,index_node_type* h,
+    do_not_copy_elements_tag):
+    super(x,al,h,do_not_copy_elements_tag()){};
+
+  ranked_index(
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list,al,h){}
 
 private:
   template<typename LowerBounder,typename UpperBounder>

--- a/include/boost/multi_index/sequenced_index.hpp
+++ b/include/boost/multi_index/sequenced_index.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -655,8 +655,10 @@ public:
   }
 
 protected:
-  sequenced_index(const ctor_args_list& args_list,const allocator_type& al):
-    super(args_list.get_tail(),al)
+  sequenced_index(
+    const ctor_args_list& args_list,
+    const allocator_type& al,index_node_type* h):
+    super(args_list.get_tail(),al,h)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)
@@ -666,8 +668,10 @@ protected:
     empty_initialize();
   }
 
-  sequenced_index(const sequenced_index<SuperMeta,TagList>& x):
-    super(x)
+  sequenced_index(
+    const sequenced_index<SuperMeta,TagList>& x,
+    const allocator_type& al,index_node_type* h):
+    super(x,al,h)
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)
@@ -678,8 +682,10 @@ protected:
   }
 
   sequenced_index(
-    const sequenced_index<SuperMeta,TagList>& x,do_not_copy_elements_tag):
-    super(x,do_not_copy_elements_tag())
+    const sequenced_index<SuperMeta,TagList>& x,
+    const allocator_type& al,index_node_type* h,
+    do_not_copy_elements_tag):
+    super(x,al,h,do_not_copy_elements_tag())
 
 #if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
     ,safe(*this)

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -156,7 +156,7 @@ public:
 
   multi_index_container():
     bfm_allocator(allocator_type()),
-    super(ctor_args_list(),bfm_allocator::member),
+    super(ctor_args_list(),bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -166,7 +166,7 @@ public:
     const ctor_args_list& args_list,
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    super(args_list,bfm_allocator::member),
+    super(args_list,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -174,7 +174,7 @@ public:
 
   explicit multi_index_container(const allocator_type& al):
     bfm_allocator(al),
-    super(ctor_args_list(),bfm_allocator::member),
+    super(ctor_args_list(),bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -186,7 +186,7 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    super(args_list,bfm_allocator::member),
+    super(args_list,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -210,7 +210,7 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    super(args_list,bfm_allocator::member),
+    super(args_list,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -236,8 +236,7 @@ public:
     bfm_allocator(
       allocator_select_on_container_copy_construction(
         x.bfm_allocator::member)),
-    bfm_header(),
-    super(x),
+    super(x,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     copy_construct_from(x);
@@ -245,8 +244,9 @@ public:
 
   multi_index_container(multi_index_container&& x):
     bfm_allocator(std::move(x.bfm_allocator::member)),
-    bfm_header(),
-    super(x,detail::do_not_copy_elements_tag()),
+    super(
+      x,bfm_allocator::member,&*bfm_header::member,
+      detail::do_not_copy_elements_tag()),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -258,8 +258,7 @@ public:
     const multi_index_container<Value,IndexSpecifierList,Allocator>& x,
     const allocator_type& al):
     bfm_allocator(al),
-    bfm_header(),
-    super(x),
+    super(x,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     copy_construct_from(x);
@@ -269,7 +268,9 @@ public:
     multi_index_container&& x,const allocator_type& al):
     bfm_allocator(al),
     bfm_header(),
-    super(x,detail::do_not_copy_elements_tag()),
+    super(
+      x,bfm_allocator::member,&*bfm_header::member,
+      detail::do_not_copy_elements_tag()),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -492,8 +493,7 @@ protected:
     const allocator_type& al,
     detail::unequal_alloc_move_ctor_tag):
     bfm_allocator(al),
-    bfm_header(),
-    super(x),
+    super(x,bfm_allocator::member,&*bfm_header::member),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT_OF(x);
@@ -524,8 +524,9 @@ protected:
     const multi_index_container<Value,IndexSpecifierList,Allocator>& x,
     detail::do_not_copy_elements_tag):
     bfm_allocator(x.bfm_allocator::member),
-    bfm_header(),
-    super(x,detail::do_not_copy_elements_tag()),
+    super(
+      x,bfm_allocator::member,&*bfm_header::member,
+      detail::do_not_copy_elements_tag()),
     node_count(0)
   {
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
@@ -551,7 +552,7 @@ protected:
 
   final_node_type* header()const
   {
-    return &*bfm_header::member();
+    return &*bfm_header::member;
   }
 
   final_node_type* allocate_node()
@@ -903,7 +904,7 @@ protected:
     boost::true_type swap_allocators)
   {
     detail::adl_swap(bfm_allocator::member,x.bfm_allocator::member);
-    std::swap(bfm_header::member(),x.bfm_header::member());
+    std::swap(bfm_header::member,x.bfm_header::member);
     super::swap_(x,swap_allocators);
     std::swap(node_count,x.node_count);
   }
@@ -912,7 +913,7 @@ protected:
     multi_index_container<Value,IndexSpecifierList,Allocator>& x,
     boost::false_type swap_allocators)
   {
-    std::swap(bfm_header::member(),x.bfm_header::member());
+    std::swap(bfm_header::member,x.bfm_header::member);
     super::swap_(x,swap_allocators);
     std::swap(node_count,x.node_count);
   }
@@ -920,7 +921,7 @@ protected:
   void swap_elements_(
     multi_index_container<Value,IndexSpecifierList,Allocator>& x)
   {
-    std::swap(bfm_header::member(),x.bfm_header::member());
+    std::swap(bfm_header::member,x.bfm_header::member);
     super::swap_elements_(x);
     std::swap(node_count,x.node_count);
   }

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -156,7 +156,6 @@ public:
 
   multi_index_container():
     bfm_allocator(allocator_type()),
-    bfm_header(),
     super(ctor_args_list(),bfm_allocator::member),
     node_count(0)
   {
@@ -167,7 +166,6 @@ public:
     const ctor_args_list& args_list,
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {
@@ -176,7 +174,6 @@ public:
 
   explicit multi_index_container(const allocator_type& al):
     bfm_allocator(al),
-    bfm_header(),
     super(ctor_args_list(),bfm_allocator::member),
     node_count(0)
   {
@@ -189,7 +186,6 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {
@@ -214,7 +210,6 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
-    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {
@@ -554,10 +549,19 @@ protected:
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
   }
 
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
   final_node_type* header()const
   {
     return &*bfm_header::member;
   }
+
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
+#pragma GCC diagnostic pop
+#endif
 
   final_node_type* allocate_node()
   {

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -87,11 +87,6 @@ struct unequal_alloc_move_ctor_tag{};
 #pragma warning(disable:4522) /* spurious warning on multiple operator=()'s */
 #endif
 
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#endif
-
 template<typename Value,typename IndexSpecifierList,typename Allocator>
 class multi_index_container:
   private ::boost::base_from_member<
@@ -554,6 +549,9 @@ protected:
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
   }
 
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
+  BOOST_NOINLINE /* bogus uninitialized warning otherwise */
+#endif
   final_node_type* header()const
   {
     return &*bfm_header::member;
@@ -1120,10 +1118,6 @@ protected:
 private:
   size_type node_count;
 };
-
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-#pragma GCC diagnostic pop /* -Wuninitialized */
-#endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC,BOOST_TESTED_AT(1500))
 #pragma warning(pop) /* C4522 */

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -550,12 +550,30 @@ protected:
   }
 
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-  BOOST_NOINLINE /* bogus uninitialized warning otherwise */
-#endif
+  /* prevents bogus uninitialized warning */
+
+  template<typename Holder, typename PtrToMember>
+  static BOOST_NOINLINE final_node_type* 
+  header_from_holder(const Holder* p,PtrToMember pm)
+  {
+    return &*(p->*pm);
+  }
+
+  final_node_type* header()const
+  {
+    using header_holder = detail::header_holder<
+      node_pointer,
+      multi_index_container>;
+
+    return header_from_holder(
+      static_cast<const header_holder*>(this),&header_holder::member);
+  }
+#else
   final_node_type* header()const
   {
     return &*bfm_header::member;
   }
+#endif
 
   final_node_type* allocate_node()
   {

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -549,31 +549,10 @@ protected:
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
   }
 
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-  /* prevents bogus uninitialized warning */
-
-  template<typename Holder, typename PtrToMember>
-  static BOOST_NOINLINE final_node_type* 
-  header_from_holder(const Holder* p,PtrToMember pm)
-  {
-    return &*(p->*pm);
-  }
-
   final_node_type* header()const
   {
-    using header_holder = detail::header_holder<
-      node_pointer,
-      multi_index_container>;
-
-    return header_from_holder(
-      static_cast<const header_holder*>(this),&header_holder::member);
+    return &*bfm_header::member();
   }
-#else
-  final_node_type* header()const
-  {
-    return &*bfm_header::member;
-  }
-#endif
 
   final_node_type* allocate_node()
   {
@@ -924,7 +903,7 @@ protected:
     boost::true_type swap_allocators)
   {
     detail::adl_swap(bfm_allocator::member,x.bfm_allocator::member);
-    std::swap(bfm_header::member,x.bfm_header::member);
+    std::swap(bfm_header::member(),x.bfm_header::member());
     super::swap_(x,swap_allocators);
     std::swap(node_count,x.node_count);
   }
@@ -933,7 +912,7 @@ protected:
     multi_index_container<Value,IndexSpecifierList,Allocator>& x,
     boost::false_type swap_allocators)
   {
-    std::swap(bfm_header::member,x.bfm_header::member);
+    std::swap(bfm_header::member(),x.bfm_header::member());
     super::swap_(x,swap_allocators);
     std::swap(node_count,x.node_count);
   }
@@ -941,7 +920,7 @@ protected:
   void swap_elements_(
     multi_index_container<Value,IndexSpecifierList,Allocator>& x)
   {
-    std::swap(bfm_header::member,x.bfm_header::member);
+    std::swap(bfm_header::member(),x.bfm_header::member());
     super::swap_elements_(x);
     std::swap(node_count,x.node_count);
   }

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -549,19 +549,17 @@ protected:
     BOOST_MULTI_INDEX_CHECK_INVARIANT;
   }
 
+  final_node_type* header()const
+  {
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
-
-  final_node_type* header()const
-  {
     return &*bfm_header::member;
-  }
-
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
 #pragma GCC diagnostic pop
 #endif
+  }
 
   final_node_type* allocate_node()
   {

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -1,6 +1,6 @@
 /* Multiply indexed container.
  *
- * Copyright 2003-2025 Joaquin M Lopez Munoz.
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -156,6 +156,7 @@ public:
 
   multi_index_container():
     bfm_allocator(allocator_type()),
+    bfm_header(),
     super(ctor_args_list(),bfm_allocator::member),
     node_count(0)
   {
@@ -166,6 +167,7 @@ public:
     const ctor_args_list& args_list,
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
+    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {
@@ -174,6 +176,7 @@ public:
 
   explicit multi_index_container(const allocator_type& al):
     bfm_allocator(al),
+    bfm_header(),
     super(ctor_args_list(),bfm_allocator::member),
     node_count(0)
   {
@@ -186,6 +189,7 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
+    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {
@@ -210,6 +214,7 @@ public:
     const ctor_args_list& args_list=ctor_args_list(),
     const allocator_type& al=allocator_type()):
     bfm_allocator(al),
+    bfm_header(),
     super(args_list,bfm_allocator::member),
     node_count(0)
   {

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -87,6 +87,11 @@ struct unequal_alloc_move_ctor_tag{};
 #pragma warning(disable:4522) /* spurious warning on multiple operator=()'s */
 #endif
 
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
 template<typename Value,typename IndexSpecifierList,typename Allocator>
 class multi_index_container:
   private ::boost::base_from_member<
@@ -551,14 +556,7 @@ protected:
 
   final_node_type* header()const
   {
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#endif
     return &*bfm_header::member;
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
-#pragma GCC diagnostic pop
-#endif
   }
 
   final_node_type* allocate_node()
@@ -1122,6 +1120,10 @@ protected:
 private:
   size_type node_count;
 };
+
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=160100)
+#pragma GCC diagnostic pop /* -Wuninitialized */
+#endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC,BOOST_TESTED_AT(1500))
 #pragma warning(pop) /* C4522 */

--- a/include/boost/multi_index_container.hpp
+++ b/include/boost/multi_index_container.hpp
@@ -267,7 +267,6 @@ public:
   multi_index_container(
     multi_index_container&& x,const allocator_type& al):
     bfm_allocator(al),
-    bfm_header(),
     super(
       x,bfm_allocator::member,&*bfm_header::member,
       detail::do_not_copy_elements_tag()),

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -37,7 +37,7 @@ project
       <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
       <toolset>msvc:<define>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
       <toolset>msvc:<cxxflags>/wd4494
-	  <toolset>gcc-16:<cxxflags>-fno-thread-jumps
+      <toolset>gcc-16:<cxxflags>-fno-thread-jumps # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119321
     ;
 
 obj boost_multi_index_key_supported : check_bmi_key_supported.cpp  ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,6 +1,6 @@
 # Boost.MultiIndex tests Jamfile
 #
-# Copyright 2003-2025 Joaquín M López Muñoz.
+# Copyright 2003-2026 Joaquín M López Muñoz.
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -37,6 +37,7 @@ project
       <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
       <toolset>msvc:<define>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
       <toolset>msvc:<cxxflags>/wd4494
+	  <toolset>gcc-16:<cxxflags>-fno-thread-jumps
     ;
 
 obj boost_multi_index_key_supported : check_bmi_key_supported.cpp  ;

--- a/test/test_alloc_awareness.cpp
+++ b/test/test_alloc_awareness.cpp
@@ -1,6 +1,6 @@
 /* Boost.MultiIndex test for allocator awareness.
  *
- * Copyright 2003-2025 Joaquin M Lopez Munoz.
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -115,7 +115,7 @@ void test_allocator_awareness_for()
     BOOST_TEST(element_transfer==(&*c3.begin()==pfirst));
     BOOST_TEST(!element_transfer==(c3.begin()->move_cted));
   }
-  if(Propagate||AlwaysEqual){
+  BOOST_IF_CONSTEXPR(Propagate||AlwaysEqual){
     container           c2(c);
     const move_tracker* pfirst=&*c2.begin();
     container           c3(root2);


### PR DESCRIPTION
Refactored internal construction chain to avoid bogus GCC 16.1 `uninitialized` and `maybe-uninitialized` warnings. Closes #96. Includes unrelated warning silencers (`alloc-size-larger-than` in GCC 16.1, C4127 in VS).