### PR TITLE
extended fancy pointer support for iterators

### DIFF
--- a/doc/reference/multi_index_container.html
+++ b/doc/reference/multi_index_container.html
@@ -552,8 +552,11 @@ scheme outlined in the
         <code>p</code> shall dereference to <code>*p</code>.
       </li>
     </ul>
+    <code>multi_index_container</code>s and all their iterators do not store references
+    to allocated elements other than through the allocator's pointer type.
   </li>
 </ol>
+
 Indices of a given <code>multi_index_container</code> instantiation cannot have
 duplicate <a href="indices.html#tags">tags</a>, either within a single
 index or in two different indices.
@@ -1069,9 +1072,9 @@ Index reference
 
 <br>
 
-<p>Revised October 25th 2025</p>
+<p>Revised June 27th 2026</p>
 
-<p>&copy; Copyright 2003-2025 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz.
+<p>&copy; Copyright 2003-2026 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz.
 Distributed under the Boost Software 
 License, Version 1.0. (See accompanying file <a href="../../../../LICENSE_1_0.txt">
 LICENSE_1_0.txt</a> or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">

--- a/doc/release_notes.html
+++ b/doc/release_notes.html
@@ -78,6 +78,11 @@ Acknowledgements
 
 <p>
 <ul>
+  <li>Fancy pointer support has been extended so that <code>multi_index_container</code>
+    iterators now store references to the elements through the allocator's pointer type.
+    In particular, this means that iterators can now be placed in shared memory using
+    <a href="../../interprocess/index.html">Boost.Interprocess</a> allocators.
+  </li>
   <li>Fixed a performance issue with hashed indices when rehashing at very large
     container sizes (<a href="https://github.com/boostorg/multi_index/pull/94">PR#94</a>).
     Contributed by Daniel Kr&aacute;l.
@@ -858,7 +863,7 @@ Acknowledgements
 
 <br>
 
-<p>Revised April 24th 2026</p>
+<p>Revised June 27th 2026</p>
 
 <p>&copy; Copyright 2003-2026 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz.
 Distributed under the Boost Software 

--- a/doc/tutorial/creation.html
+++ b/doc/tutorial/creation.html
@@ -201,7 +201,7 @@ than strictly required by the C++ standard, as explained in detail in the
 An important type of non-standard allocators supported are those provided by the
 <a href="../../../interprocess/index.html">Boost Interprocess Library</a>;
 this opens up the possibility of placing <code>multi_index_container</code>s
-in shared memory.
+and their iterators in shared memory.
 </p>
 
 <blockquote><pre>
@@ -340,9 +340,9 @@ Debugging support
 
 <br>
 
-<p>Revised July 17th 2007</p>
+<p>Revised June 27th 2026</p>
 
-<p>&copy; Copyright 2003-2007 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz.
+<p>&copy; Copyright 2003-2026 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz.
 Distributed under the Boost Software 
 License, Version 1.0. (See accompanying file <a href="../../../../LICENSE_1_0.txt">
 LICENSE_1_0.txt</a> or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">

--- a/include/boost/multi_index/detail/bidir_node_iterator.hpp
+++ b/include/boost/multi_index/detail/bidir_node_iterator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2023 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +14,7 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/multi_index/detail/raw_ptr.hpp>
 #include <boost/operators.hpp>
 
 #if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
@@ -77,7 +78,7 @@ public:
   template<class Archive>
   void save(Archive& ar,const unsigned int)const
   {
-    node_base_type* bnode=node;
+    node_base_type* bnode=get_node();
     ar<<core::make_nvp("pointer",bnode);
   }
 
@@ -86,7 +87,7 @@ public:
   {
     node_base_type* bnode;
     ar>>core::make_nvp("pointer",bnode);
-    node=static_cast<Node*>(bnode);
+    node=typename Node::pointer(static_cast<Node*>(bnode));
   }
 #endif
 
@@ -94,10 +95,10 @@ public:
 
   typedef Node node_type;
 
-  Node* get_node()const{return node;}
+  Node* get_node()const{return raw_ptr<Node*>(node);}
 
 private:
-  Node* node;
+  typename Node::pointer node;
 };
 
 template<typename Node>

--- a/include/boost/multi_index/detail/hash_index_iterator.hpp
+++ b/include/boost/multi_index/detail/hash_index_iterator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2023 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +14,7 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/multi_index/detail/raw_ptr.hpp>
 #include <boost/operators.hpp>
 
 #if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
@@ -76,7 +77,7 @@ public:
   template<class Archive>
   void save(Archive& ar,const unsigned int)const
   {
-    node_base_type* bnode=node;
+    node_base_type* bnode=get_node();
     ar<<core::make_nvp("pointer",bnode);
   }
 
@@ -92,7 +93,7 @@ public:
   {
     node_base_type* bnode;
     ar>>core::make_nvp("pointer",bnode);
-    node=static_cast<Node*>(bnode);
+    node=typename Node::pointer(static_cast<Node*>(bnode));
     if(version<1){
       BucketArray* throw_away; /* consume unused ptr */
       ar>>core::make_nvp("pointer",throw_away);
@@ -105,13 +106,13 @@ public:
   {
     node_base_type* bnode;
     ar>>core::make_nvp("pointer",bnode);
-    node=static_cast<Node*>(bnode);
+    node=typename Node::pointer(static_cast<Node*>(bnode));
     if(version<1){
       BucketArray* buckets;
       ar>>core::make_nvp("pointer",buckets);
-      if(buckets&&node&&node->impl()==buckets->end()->prior()){
+      if(buckets&&bnode&&node->impl()==buckets->end()->prior()){
         /* end local_iterators used to point to end node, now they are null */
-        node=0;
+        node=typename Node::pointer(0);
       }
     }
   }
@@ -121,7 +122,7 @@ public:
 
   typedef Node node_type;
 
-  Node* get_node()const{return node;}
+  Node* get_node()const{return raw_ptr<Node*>(node);}
 
 private:
 
@@ -135,7 +136,7 @@ private:
     Node::template increment_local<IndexCategory>(node);
   }
 
-  Node* node;
+  typename Node::pointer node;
 };
 
 template<

--- a/include/boost/multi_index/detail/hash_index_node.hpp
+++ b/include/boost/multi_index/detail/hash_index_node.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -712,6 +712,13 @@ public:
   typedef typename trampoline::pointer            impl_pointer;
   typedef typename trampoline::const_pointer      const_impl_pointer;
   typedef typename trampoline::difference_type    difference_type;
+  typedef allocator_rebind_t<
+    typename trampoline::impl_allocator_type,
+    hashed_index_node>                            final_allocator_type;
+  typedef allocator_pointer_t<
+    final_allocator_type>                         pointer;
+  typedef allocator_const_pointer_t<
+    final_allocator_type>                         const_pointer;
 
   template<typename Category>
   struct node_alg{
@@ -754,15 +761,15 @@ public:
   /* interoperability with hashed_index_iterator */
 
   template<typename Category>
-  static void increment(hashed_index_node*& x)
+  static void increment(pointer& x)
   {
-    x=from_impl(node_alg<Category>::type::after(x->impl()));
+    x=pointer(from_impl(node_alg<Category>::type::after(x->impl())));
   }
 
   template<typename Category>
-  static void increment_local(hashed_index_node*& x)
+  static void increment_local(pointer& x)
   {
-    x=from_impl(node_alg<Category>::type::after_local(x->impl()));
+    x=pointer(from_impl(node_alg<Category>::type::after_local(x->impl())));
   }
 };
 

--- a/include/boost/multi_index/detail/ord_index_node.hpp
+++ b/include/boost/multi_index/detail/ord_index_node.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -131,6 +131,7 @@ struct ordered_index_node_compressed_base
 {
   typedef ordered_index_node_traits<
     AugmentPolicy,Allocator>                    node_traits;
+  typedef typename node_traits::allocator       node_allocator;
   typedef ordered_index_node_impl<
     AugmentPolicy,Allocator>*                   pointer;
   typedef const ordered_index_node_impl<
@@ -608,6 +609,14 @@ public:
   typedef typename trampoline::const_pointer   const_impl_pointer;
   typedef typename trampoline::difference_type difference_type;
   typedef typename trampoline::size_type       size_type;
+  typedef allocator_rebind_t<
+    typename trampoline::node_allocator,
+    ordered_index_node>                        final_allocator_type;
+  typedef allocator_pointer_t<
+    final_allocator_type>                      pointer;
+  typedef allocator_const_pointer_t<
+    final_allocator_type>                      const_pointer;
+
 
   impl_color_ref      color(){return trampoline::color();}
   ordered_index_color color()const{return trampoline::color();}
@@ -646,20 +655,24 @@ public:
           raw_ptr<const impl_type*>(x)));
   }
 
-  /* interoperability with bidir_node_iterator */
+  /* Interoperability with bidir_node_iterator and index impl.
+   * Templated for raw-pointer/non-raw-pointer versions.
+   */
 
-  static void increment(ordered_index_node*& x)
+  template<typename NodePtr>
+  static void increment(NodePtr& x)
   {
     impl_pointer xi=x->impl();
     trampoline::increment(xi);
-    x=from_impl(xi);
+    x=NodePtr(from_impl(xi));
   }
 
-  static void decrement(ordered_index_node*& x)
+  template<typename NodePtr>
+  static void decrement(NodePtr& x)
   {
     impl_pointer xi=x->impl();
     trampoline::decrement(xi);
-    x=from_impl(xi);
+    x=NodePtr(from_impl(xi));
   }
 };
 

--- a/include/boost/multi_index/detail/rnd_index_node.hpp
+++ b/include/boost/multi_index/detail/rnd_index_node.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -215,11 +215,18 @@ private:
   typedef random_access_index_node_trampoline<Super> trampoline;
 
 public:
-  typedef typename trampoline::impl_type         impl_type;
-  typedef typename trampoline::pointer           impl_pointer;
-  typedef typename trampoline::const_pointer     const_impl_pointer;
-  typedef typename trampoline::difference_type   difference_type;
-  typedef typename trampoline::ptr_pointer       impl_ptr_pointer;
+  typedef typename trampoline::impl_type       impl_type;
+  typedef typename trampoline::pointer         impl_pointer;
+  typedef typename trampoline::const_pointer   const_impl_pointer;
+  typedef typename trampoline::difference_type difference_type;
+  typedef typename trampoline::ptr_pointer     impl_ptr_pointer;
+  typedef allocator_rebind_t<
+    typename trampoline::node_allocator,
+    random_access_index_node>                  final_allocator_type;
+  typedef allocator_pointer_t<
+    final_allocator_type>                      pointer;
+  typedef allocator_const_pointer_t<
+    final_allocator_type>                      const_pointer;
 
   impl_ptr_pointer& up(){return trampoline::up();}
   impl_ptr_pointer  up()const{return trampoline::up();}
@@ -254,25 +261,25 @@ public:
 
   /* interoperability with rnd_node_iterator */
 
-  static void increment(random_access_index_node*& x)
+  static void increment(pointer& x)
   {
     impl_pointer xi=x->impl();
     trampoline::increment(xi);
-    x=from_impl(xi);
+    x=pointer(from_impl(xi));
   }
 
-  static void decrement(random_access_index_node*& x)
+  static void decrement(pointer& x)
   {
     impl_pointer xi=x->impl();
     trampoline::decrement(xi);
-    x=from_impl(xi);
+    x=pointer(from_impl(xi));
   }
 
-  static void advance(random_access_index_node*& x,difference_type n)
+  static void advance(pointer& x,difference_type n)
   {
     impl_pointer xi=x->impl();
     trampoline::advance(xi,n);
-    x=from_impl(xi);
+    x=pointer(from_impl(xi));
   }
 
   static difference_type distance(

--- a/include/boost/multi_index/detail/rnd_node_iterator.hpp
+++ b/include/boost/multi_index/detail/rnd_node_iterator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2023 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +14,7 @@
 #endif
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/multi_index/detail/raw_ptr.hpp>
 #include <boost/operators.hpp>
 
 #if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
@@ -87,7 +88,7 @@ public:
   template<class Archive>
   void save(Archive& ar,const unsigned int)const
   {
-    node_base_type* bnode=node;
+    node_base_type* bnode=get_node();
     ar<<core::make_nvp("pointer",bnode);
   }
 
@@ -96,7 +97,7 @@ public:
   {
     node_base_type* bnode;
     ar>>core::make_nvp("pointer",bnode);
-    node=static_cast<Node*>(bnode);
+    node=typename Node::pointer(static_cast<Node*>(bnode));
   }
 #endif
 
@@ -104,10 +105,10 @@ public:
 
   typedef Node node_type;
 
-  Node* get_node()const{return node;}
+  Node* get_node()const{return raw_ptr<Node*>(node);}
 
 private:
-  Node* node;
+  typename Node::pointer node;
 };
 
 template<typename Node>

--- a/include/boost/multi_index/detail/seq_index_node.hpp
+++ b/include/boost/multi_index/detail/seq_index_node.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2025 Joaquin M Lopez Munoz.
+/* Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -158,6 +158,13 @@ public:
   typedef typename trampoline::pointer         impl_pointer;
   typedef typename trampoline::const_pointer   const_impl_pointer;
   typedef typename trampoline::difference_type difference_type;
+  typedef allocator_rebind_t<
+    typename trampoline::node_allocator,
+    sequenced_index_node>                      final_allocator_type;
+  typedef allocator_pointer_t<
+    final_allocator_type>                      pointer;
+  typedef allocator_const_pointer_t<
+    final_allocator_type>                      const_pointer;
 
   impl_pointer& prior(){return trampoline::prior();}
   impl_pointer  prior()const{return trampoline::prior();}
@@ -192,20 +199,24 @@ public:
           raw_ptr<const impl_type*>(x)));
   }
 
-  /* interoperability with bidir_node_iterator */
+  /* Interoperability with bidir_node_iterator and index impl.
+   * Templated for raw-pointer/non-raw-pointer versions.
+   */
 
-  static void increment(sequenced_index_node*& x)
+  template<typename NodePtr>
+  static void increment(NodePtr& x)
   {
     impl_pointer xi=x->impl();
     trampoline::increment(xi);
-    x=from_impl(xi);
+    x=NodePtr(from_impl(xi));
   }
 
-  static void decrement(sequenced_index_node*& x)
+  template<typename NodePtr>
+  static void decrement(NodePtr& x)
   {
     impl_pointer xi=x->impl();
     trampoline::decrement(xi);
-    x=from_impl(xi);
+    x=NodePtr(from_impl(xi));
   }
 };
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -53,7 +53,7 @@ test-suite "multi_index" :
     [ run test_copy_assignment.cpp  test_copy_assignment_main.cpp  ]
     [ run test_hash_ops.cpp         test_hash_ops_main.cpp         ]
     [ run test_iterators.cpp        test_iterators_main.cpp
-        /boost/foreach//boost_foreach                              ]
+          /boost/foreach//boost_foreach                            ]
     [ run test_key.cpp              test_key_main.cpp
         : : :
         [ check-target-builds boost_multi_index_key_supported
@@ -61,6 +61,9 @@ test-suite "multi_index" :
             : : <build>no                                        ] ]
     [ run test_key_extractors.cpp   test_key_extractors_main.cpp   ]
     [ run test_list_ops.cpp         test_list_ops_main.cpp         ]
+    [ run test_mmap.cpp             test_mmap_main.cpp             
+          /boost/interprocess//boost_interprocess
+          /boost/uuid//boost_uuid                                  ]
     [ run test_modifiers.cpp        test_modifiers_main.cpp        ]
     [ run test_mpl_ops.cpp          test_mpl_ops_main.cpp          ]
     [ run test_node_handling.cpp    test_node_handling_main.cpp    ]

--- a/test/test_all_main.cpp
+++ b/test/test_all_main.cpp
@@ -1,6 +1,6 @@
 /* Boost.MultiIndex test suite.
  *
- * Copyright 2003-2020 Joaquin M Lopez Munoz.
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -21,6 +21,7 @@
 #include "test_key.hpp"
 #include "test_key_extractors.hpp"
 #include "test_list_ops.hpp"
+#include "test_mmap.hpp"
 #include "test_modifiers.hpp"
 #include "test_mpl_ops.hpp"
 #include "test_node_handling.hpp"
@@ -49,6 +50,7 @@ int main()
   test_key();
   test_key_extractors();
   test_list_ops();
+  test_mmap();
   test_modifiers();
   test_mpl_ops();
   test_node_handling();

--- a/test/test_mmap.cpp
+++ b/test/test_mmap.cpp
@@ -1,0 +1,86 @@
+/* Boost.MultiIndex test for memory relocatability.
+ *
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#include "test_mmap.hpp"
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/interprocess/file_mapping.hpp>
+#include <boost/interprocess/managed_mapped_file.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/ranked_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+void test_mmap()
+{
+  using namespace boost::multi_index;
+  namespace bip=boost::interprocess;
+  using container=multi_index_container<
+    int,
+    indexed_by<
+      ordered_unique<identity<int>>,
+      hashed_unique<identity<int>>,
+      ranked_unique<identity<int>>,
+      sequenced<>,
+      random_access<>
+    >,
+    bip::allocator<int,bip::managed_mapped_file::segment_manager>
+  >;
+  using iterator0=nth_index<container,0>::type::iterator;
+  using iterator1=nth_index<container,1>::type::iterator;
+  using iterator2=nth_index<container,2>::type::iterator;
+  using iterator3=nth_index<container,3>::type::iterator;
+  using iterator4=nth_index<container,4>::type::iterator;
+  constexpr auto container_name="container";
+
+  static auto file_name_str= 
+    std::string("./test_mmap_")+
+    to_string(boost::uuids::random_generator()());
+  static auto file_name=file_name_str.c_str();
+  
+  bip::file_mapping::remove(file_name);
+  auto pseg1=std::make_unique<bip::managed_mapped_file>(
+    bip::create_only,file_name,65536);
+  container& c1=*pseg1->construct<container>(container_name)(
+    container::ctor_args_list(),
+    container::allocator_type(pseg1->get_segment_manager()));
+  for(int i=0;i<100;++i)c1.insert(i);
+  auto v0=**pseg1->construct<iterator0>("it0")(c1.get<0>().begin());
+  auto v1=**pseg1->construct<iterator1>("it1")(c1.get<1>().begin());
+  auto v2=**pseg1->construct<iterator2>("it2")(c1.get<2>().begin());
+  auto v3=**pseg1->construct<iterator3>("it3")(c1.get<3>().begin());
+  auto v4=**pseg1->construct<iterator4>("it4")(c1.get<4>().begin());
+
+  bip::managed_mapped_file seg2(bip::open_only,file_name);
+  pseg1=nullptr;
+  container& c2=*seg2.find<container>(container_name).first;
+  auto it0=*seg2.find<iterator0>("it0").first;
+  auto it1=*seg2.find<iterator1>("it1").first;
+  auto it2=*seg2.find<iterator2>("it2").first;
+  auto it3=*seg2.find<iterator3>("it3").first;
+  auto it4=*seg2.find<iterator4>("it4").first;
+  BOOST_TEST_EQ(*it0,v0);
+  BOOST_TEST_EQ(std::distance(it0,c2.get<0>().end()),c2.size());
+  BOOST_TEST_EQ(*it1,v1);
+  BOOST_TEST_EQ(std::distance(it1,c2.get<1>().end()),c2.size());
+  BOOST_TEST_EQ(*it2,v2);
+  BOOST_TEST_EQ(std::distance(it2,c2.get<2>().end()),c2.size());
+  BOOST_TEST_EQ(*it3,v3);
+  BOOST_TEST_EQ(std::distance(it3,c2.get<3>().end()),c2.size());
+  BOOST_TEST_EQ(*it4,v4);
+  BOOST_TEST_EQ(std::distance(it4,c2.get<4>().end()),c2.size());
+}

--- a/test/test_mmap.cpp
+++ b/test/test_mmap.cpp
@@ -56,8 +56,8 @@ void test_mmap()
   static auto file_name=file_name_str.c_str();
   
   bip::file_mapping::remove(file_name);
-  auto pseg1=std::make_unique<bip::managed_mapped_file>(
-    bip::create_only,file_name,65536);
+  std::unique_ptr<bip::managed_mapped_file> pseg1(
+    new bip::managed_mapped_file(bip::create_only,file_name,65536));
   container& c1=*pseg1->construct<container>(container_name)(
     container::ctor_args_list(),
     container::allocator_type(pseg1->get_segment_manager()));

--- a/test/test_mmap.cpp
+++ b/test/test_mmap.cpp
@@ -24,6 +24,9 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <iterator>
+#include <memory>
+#include <string>
 
 void test_mmap()
 {

--- a/test/test_mmap.cpp
+++ b/test/test_mmap.cpp
@@ -45,6 +45,7 @@ void test_mmap()
   >;
   using iterator0=nth_index<container,0>::type::iterator;
   using iterator1=nth_index<container,1>::type::iterator;
+  using local_iterator1=nth_index<container,1>::type::local_iterator;
   using iterator2=nth_index<container,2>::type::iterator;
   using iterator3=nth_index<container,3>::type::iterator;
   using iterator4=nth_index<container,4>::type::iterator;
@@ -64,6 +65,7 @@ void test_mmap()
   for(int i=0;i<100;++i)c1.insert(i);
   auto v0=**pseg1->construct<iterator0>("it0")(c1.get<0>().begin());
   auto v1=**pseg1->construct<iterator1>("it1")(c1.get<1>().begin());
+  auto lv1=**pseg1->construct<local_iterator1>("lit1")(c1.get<1>().begin(0));
   auto v2=**pseg1->construct<iterator2>("it2")(c1.get<2>().begin());
   auto v3=**pseg1->construct<iterator3>("it3")(c1.get<3>().begin());
   auto v4=**pseg1->construct<iterator4>("it4")(c1.get<4>().begin());
@@ -73,6 +75,7 @@ void test_mmap()
   container& c2=*seg2.find<container>(container_name).first;
   auto it0=*seg2.find<iterator0>("it0").first;
   auto it1=*seg2.find<iterator1>("it1").first;
+  auto lit1=*seg2.find<local_iterator1>("lit1").first;
   auto it2=*seg2.find<iterator2>("it2").first;
   auto it3=*seg2.find<iterator3>("it3").first;
   auto it4=*seg2.find<iterator4>("it4").first;
@@ -80,6 +83,9 @@ void test_mmap()
   BOOST_TEST_EQ(std::distance(it0,c2.get<0>().end()),c2.size());
   BOOST_TEST_EQ(*it1,v1);
   BOOST_TEST_EQ(std::distance(it1,c2.get<1>().end()),c2.size());
+  BOOST_TEST_EQ(*lit1,lv1);
+  BOOST_TEST_EQ(
+    std::distance(lit1,c2.get<1>().end(0)),c2.get<1>().bucket_size(0));
   BOOST_TEST_EQ(*it2,v2);
   BOOST_TEST_EQ(std::distance(it2,c2.get<2>().end()),c2.size());
   BOOST_TEST_EQ(*it3,v3);

--- a/test/test_mmap.hpp
+++ b/test/test_mmap.hpp
@@ -1,0 +1,11 @@
+/* Boost.MultiIndex test for memory relocatability.
+ *
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+void test_mmap();

--- a/test/test_mmap_main.cpp
+++ b/test/test_mmap_main.cpp
@@ -1,0 +1,19 @@
+/* Boost.MultiIndex test for memory relocatability.
+ *
+ * Copyright 2003-2026 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#include <boost/detail/lightweight_test.hpp>
+#include "test_mmap.hpp"
+
+int main()
+{
+  test_mmap();
+  return boost::report_errors();
+}
+


### PR DESCRIPTION
Fancy pointer support has been extended so that `multi_index_container` iterators now store references to the elements through the allocator's pointer type. In particular, this means that iterators can now be placed in shared memory using Boost.Interprocessallocators.